### PR TITLE
Updated README with instructions for user to export their OpenAI API Key

### DIFF
--- a/agents/openai_agents_sdk_python/README.md
+++ b/agents/openai_agents_sdk_python/README.md
@@ -6,12 +6,8 @@ priority: 750
 -->
 
 # Durable Agent using OpenAI Agents SDK
-=======
-priority: 5
--->
 
 # Hello World - Agent with Tools
->>>>>>> origin/main
 
 In this example, we show you how to build a Durable Agent using the [OpenAI Agents SDK Integration for Temporal](https://github.com/temporalio/sdk-python/tree/main/temporalio/contrib/openai_agents). The AI agent we build will have access to [tools](https://github.com/temporalio/sdk-python/tree/main/temporalio/contrib/openai_agents#tool-calling) (Temporal Activities) to answer user questions. The agent can determine which tools to use based on the user's input and execute them as needed.
 


### PR DESCRIPTION
Minor change - README was missing instructions for the requirement of an OpenAI API Key when using the OpenAI Agents SDK
