### PR TITLE
Create MAINTAINERS.md with project leadership details

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -24,8 +24,8 @@ AI Cookbook is a cross-functional initiative, and liaisons represent their funct
 ### AI Engineering liaison
 - TBD member of the AI SDK team
 
-### AI DevRel liaison
-- TBD member of the AI DevRel team
+### DevRel liaison
+- [Cecil Philip](https://github.com/cecilphillip) (to be confirmed)
 
 ### Documentation and Tooling liaison
 - TBD member of the Documentation and Tooling team

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -11,28 +11,24 @@ The Technical Strategist works with the Product Owner to define and prioritize t
 
 - [Cornelia Davis](https://github.com/cdavisafc)
 
-## Solution Architect liaisons
-The Solution Architect liaisons ensure that Solution Architect feedback is reflected in the priorities of the project, and help secure other Solution Architect folks if needed to make progress on reviews.
+## Cross-functional liaisons
+AI Cookbook is a cross-functional initiative, and liaisons represent their functions' unique viewpoints and provide feedback into the priorities and roadmap of the project. They also help secure other folks from their respetive teams if needed to make progress on recipes and reviews.
 
+### Solution Architect liaisons
 - Growth: [Josh Smith](https://github.com/joshmsmith)
 - Commercial: [MasonEgger](https://github.com/MasonEgger)
 
-## Product liaison
-The Product liaisons ensures that Product feedback is reflected in the priorities of the project, and help secure other Product folks if needed to make progress on reviews.
-
+### Product liaison
 - [Ethan Ruhe](https://github.com/ethanruhe) (to be confirmed)
 
-## AI Engineering liaison
-The AI Engineering liaison ensures that Engineering feedback is reflected in the priorities of the project, and help secure other Engineering folks if needed to make progress on reviews.
-
+### AI Engineering liaison
 - TBD member of the AI SDK team
 
-## Documentation liaison
-...
+### AI DevRel liaison
+- TBD member of the AI DevRel team
 
+### Documentation and Tooling liaison
 - TBD member of the Documentation and Tooling team
-
-## (other leadership roles...)
 
 # Technical reviewers
 Technical reviewers ensure that contributors' submissions are looked at in a timely manner, provide architectural guidance, etc.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -11,8 +11,8 @@ The AI Engineering liaison ensures that Engineering feedback is reflected in the
 
 - [Johann Schleier-Smith](https://github.com/jssmith) (to be confirmed)
 
-## Solution Archirect liaison
-The Solition Archirect liaison ensures that Solition Archirect feedback is reflected in the priorities of the project, and help secure other Solition Archirect folks if needed to make progress on reviews.
+## Solution Architect liaison
+The Solution Architect liaison ensures that Solution Architect feedback is reflected in the priorities of the project, and help secure other Solution Architect folks if needed to make progress on reviews.
 
 - [Josh Smith](https://github.com/joshmsmith) (to be confirmed)
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,60 @@
+# Project leadership
+Maintainers that are part of Project Leadership make decisions about the project's priorities, roadmap, and future direction.
+
+## Product owner
+The Product Owner is responsible for taking in feedback from stakeholders and making decisions around backlog prioritization and product roadmap. They also hold a cadence with technical reviewers to ensure contributors are getting timely attention to their submissions.
+
+- [Angie Byron](https://github.com/webchick) (interim)
+
+## AI Engineering liaison
+The AI Engineering liaison ensures that Engineering feedback is reflected in the priorities of the project, and help secure other Engineering folks if needed to make progress on reviews.
+
+- [Johann Schleier-Smith](https://github.com/jssmith) (to be confirmed)
+
+## Solution Archirect liaison
+The Solition Archirect liaison ensures that Solition Archirect feedback is reflected in the priorities of the project, and help secure other Solition Archirect folks if needed to make progress on reviews.
+
+- [Josh Smith](https://github.com/joshmsmith) (to be confirmed)
+
+## (other leadership roles...)
+
+# Technical reviewers
+Technical reviewers ensure that contributors' submissions are looked at in a timely manner, provide architectural guidance, etc.
+
+## General
+- TBD
+
+## Python examples
+- TBD
+
+## TypeScript examples
+- TBD
+
+## Java examples
+- TBD
+
+## Go examples
+- TBD
+
+## .NET examples
+- TBD
+
+## (other SDKs TBD)
+
+# Tooling
+Tooling maintainers give care and feeding to the infrastructure underpinning the project.
+
+## Documentation Tooling
+- [Lenny Chen](https://github.com/lennessyy) (to be confirmed)
+
+## CI/CD Tooling
+- TBD
+
+## Automated Testing Tooling
+- TBD
+
+# Emeritus maintainers
+We would like to thank these folks for all of their fantastic work shepherding the AI Cookbook project forward!
+
+- [Cornelia Davis](https://github.com/cdavisafc) (to be confirmed)
+- [Rob Holland](https://github.com/robholland)

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -63,7 +63,7 @@ Tooling maintainers give care and feeding to the infrastructure underpinning the
 ## Documentation Tooling
 - [Lenny Chen](https://github.com/lennessyy)
 
-## Standards Tooling
+## Automated Content + Standards Tooling
 - [Mason Egger](https://github.com/MasonEgger)
 
 ## CI/CD Tooling

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -6,6 +6,11 @@ The Product Owner is responsible for taking in feedback from stakeholders and ma
 
 - [Angie Byron](https://github.com/webchick) (interim)
 
+## Technical strategist
+The Technical Strategist works with the Product Owner to define and prioritize the product roadmap, and is available to consult on technical matters.
+
+- [Cornelia Davis](https://github.com/cdavisafc)
+
 ## Solution Architect liaisons
 The Solution Architect liaisons ensure that Solution Architect feedback is reflected in the priorities of the project, and help secure other Solution Architect folks if needed to make progress on reviews.
 
@@ -71,5 +76,4 @@ Tooling maintainers give care and feeding to the infrastructure underpinning the
 We would like to thank these folks for all of their fantastic work shepherding the AI Cookbook project forward!
 
 - [Johann Schleier-Smith](https://github.com/jssmith)
-- [Cornelia Davis](https://github.com/cdavisafc) (to be confirmed)
 - [Rob Holland](https://github.com/robholland)

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -14,7 +14,7 @@ The AI Engineering liaison ensures that Engineering feedback is reflected in the
 ## Solution Architect liaison
 The Solution Architect liaison ensures that Solution Architect feedback is reflected in the priorities of the project, and help secure other Solution Architect folks if needed to make progress on reviews.
 
-- [Josh Smith](https://github.com/joshmsmith) (to be confirmed)
+- [Josh Smith](https://github.com/joshmsmith)
 
 ## (other leadership roles...)
 
@@ -45,7 +45,7 @@ Technical reviewers ensure that contributors' submissions are looked at in a tim
 Tooling maintainers give care and feeding to the infrastructure underpinning the project.
 
 ## Documentation Tooling
-- [Lenny Chen](https://github.com/lennessyy) (to be confirmed)
+- [Lenny Chen](https://github.com/lennessyy)
 
 ## CI/CD Tooling
 - TBD

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -47,6 +47,9 @@ Tooling maintainers give care and feeding to the infrastructure underpinning the
 ## Documentation Tooling
 - [Lenny Chen](https://github.com/lennessyy)
 
+## Standards Tooling
+- [Mason Egger](https://github.com/MasonEgger)
+
 ## CI/CD Tooling
 - TBD
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -2,19 +2,30 @@
 Maintainers that are part of Project Leadership make decisions about the project's priorities, roadmap, and future direction.
 
 ## Product owner
-The Product Owner is responsible for taking in feedback from stakeholders and making decisions around backlog prioritization and product roadmap. They also hold a cadence with technical reviewers to ensure contributors are getting timely attention to their submissions.
+The Product Owner is responsible for taking in feedback from stakeholders and maintaining the project backlog and product roadmap. They also hold a cadence with technical reviewers to ensure contributors are getting timely attention to their submissions.
 
 - [Angie Byron](https://github.com/webchick) (interim)
+
+## Solution Architect liaisons
+The Solution Architect liaisons ensure that Solution Architect feedback is reflected in the priorities of the project, and help secure other Solution Architect folks if needed to make progress on reviews.
+
+- Growth: [Josh Smith](https://github.com/joshmsmith)
+- Commercial: [MasonEgger](https://github.com/MasonEgger)
+
+## Product liaison
+The Product liaisons ensures that Product feedback is reflected in the priorities of the project, and help secure other Product folks if needed to make progress on reviews.
+
+- [Ethan Ruhe](https://github.com/ethanruhe) (to be confirmed)
 
 ## AI Engineering liaison
 The AI Engineering liaison ensures that Engineering feedback is reflected in the priorities of the project, and help secure other Engineering folks if needed to make progress on reviews.
 
-- [Johann Schleier-Smith](https://github.com/jssmith) (to be confirmed)
+- TBD member of the AI SDK team
 
-## Solution Architect liaison
-The Solution Architect liaison ensures that Solution Architect feedback is reflected in the priorities of the project, and help secure other Solution Architect folks if needed to make progress on reviews.
+## Documentation liaison
+...
 
-- [Josh Smith](https://github.com/joshmsmith)
+- TBD member of the Documentation and Tooling team
 
 ## (other leadership roles...)
 
@@ -59,5 +70,6 @@ Tooling maintainers give care and feeding to the infrastructure underpinning the
 # Emeritus maintainers
 We would like to thank these folks for all of their fantastic work shepherding the AI Cookbook project forward!
 
+- [Johann Schleier-Smith](https://github.com/jssmith)
 - [Cornelia Davis](https://github.com/cdavisafc) (to be confirmed)
 - [Rob Holland](https://github.com/robholland)


### PR DESCRIPTION
## What was changed
Documented the current "do-ocracy" around this project by defining roles for project leadership, technical reviewers, and tooling, along with what those roles mean, and who the people are who seem to be doing those things right now.

## Why?
Resolves #97 (or will, when it's done :))

## Checklist

1. Get confirmation from "to be confirmed" folks
2. Try and fill as many "TBD"s as possible
3. 🚢 it!
