### PR TITLE
Add /project:recipe-ify Claude Code command

### DIFF
--- a/.claude/commands/recipe-ify.md
+++ b/.claude/commands/recipe-ify.md
@@ -67,14 +67,25 @@ For each candidate pattern you find, evaluate:
 5. **Is it novel vs. existing recipes?** Check existing recipes in this repo (foundations/, agents/, deep_research/, mcp/) and flag if a very similar recipe already exists.
 6. **Does it fill a wishlist gap?** Cross-reference against the coverage wishlist above.
 
-Rank the top 2–4 patterns. For each, give:
-- A proposed recipe name (kebab-case, ending in `_python`)
-- A proposed category (foundations, agents, deep_research, or mcp)
-- A one-sentence description for the README front matter
-- The key files from the source project that the recipe would draw from
-- The AI concept the developer learns — framed for someone who knows LLMs but not Temporal
+Rank the top 2–4 patterns. For each, provide a proposal card with the following sections — written so a reviewer who has never seen the source project can evaluate it:
 
-If a pattern you found is interesting but primarily a Temporal/infrastructure concern rather than an AI building block, note it briefly and explain why it was excluded.
+**Proposed recipe:** `{category}/{recipe-name}_python`
+
+**One-line description:** _(the README front matter `description` field)_
+
+**The problem it solves:** In 2–3 sentences: what goes wrong if a developer doesn't know this pattern? What mistake do they typically make, and what does that cost them?
+
+**The pattern in the source:** A short code excerpt (10–25 lines) from the source project that shows the pattern at its clearest. If the source isn't Python or doesn't translate directly, describe the equivalent pseudocode. This is the "exhibit A" that justifies the recipe.
+
+**How the recipe would be structured:** A brief outline — what the workflow does, what the key activity does, what tool or API is involved. Not full code, just enough for a reviewer to picture the finished recipe. Should be 5–10 bullet points.
+
+**Closest existing recipe and what's different:** Name the most similar recipe already in the cookbook and state specifically what this recipe adds or changes. If there's no close match, say so.
+
+**Wishlist gap filled:** Which item from the coverage wishlist does this address, if any? If none, say so.
+
+**Estimated size:** Rough line count for the finished recipe (all files combined). Flag anything over 400 lines as potentially too complex for a single recipe.
+
+If a pattern you found is interesting but primarily a Temporal/infrastructure concern rather than an AI building block, list it in a separate "Excluded patterns" section with a one-line reason for each.
 
 Ask the user which recipe(s) to generate before proceeding.
 

--- a/.claude/commands/recipe-ify.md
+++ b/.claude/commands/recipe-ify.md
@@ -1,0 +1,123 @@
+# Recipe-ify
+
+Analyze an external project and generate a draft recipe (or multiple) for the ai-cookbook.
+
+Usage: `/project:recipe-ify <github-url>`
+
+## What you do
+
+You are an expert at extracting teachable, self-contained patterns from real-world AI projects and turning them into cookbook recipes in the exact format this repo uses. Work through the following steps.
+
+---
+
+### Step 1 — Fetch and analyze the project
+
+Fetch the repository at `$ARGUMENTS`. Collect:
+- The README (for intent and architecture overview)
+- The full file tree (via GitHub API: `https://api.github.com/repos/{owner}/{repo}/git/trees/main?recursive=1`)
+- Key source files: workflow definitions, activity implementations, LLM integration code, any agent/tool patterns
+
+Look specifically for these patterns, which make strong recipes:
+- **Agentic loops** — LLM calls in a loop until stop condition (tool use, stop sequence, empty choices)
+- **Forced completion** — Constraining tool choice on the final loop iteration to force a decision
+- **Parallel activities** — Multiple independent async activities launched concurrently with `asyncio.gather`
+- **Graceful degradation** — Activities that catch their own failures and return defaults rather than propagating
+- **Workflow deduplication** — Using a deterministic workflow ID as a cache/dedup key across triggers
+- **Prompt caching** — `cache_control: ephemeral` or equivalent to amortize repeated system prompts
+- **Structured output validation** — LLM outputs validated through a Pydantic schema
+- **Human-in-the-loop** — Workflow pauses awaiting a signal or external approval
+- **Prompt injection prevention** — Untrusted data isolated from control instructions via XML tags or similar
+- **Multi-provider abstraction** — Single interface dispatching to Anthropic, OpenAI, LiteLLM, etc.
+- **Signal/Query handlers** — Workflows that expose runtime state or accept commands
+
+---
+
+### Step 2 — Recommend which patterns to extract
+
+For each candidate pattern you find, evaluate:
+1. **Is it self-contained?** Can it stand alone as a 200–400 line recipe without pulling in the entire project?
+2. **Is it teachable?** Does it demonstrate a single clear concept a developer can learn from?
+3. **Is it novel vs. existing recipes?** Check existing recipes in this repo (foundations/, agents/, deep_research/, mcp/) and flag if a very similar recipe already exists.
+
+Rank the top 2–4 patterns. For each, give:
+- A proposed recipe name (kebab-case, ending in `_python`)
+- A proposed category (foundations, agents, deep_research, or mcp)
+- A one-sentence description for the README front matter
+- The key files from the source project that the recipe would draw from
+- Why this pattern matters / what a developer learns from it
+
+Ask the user which recipe(s) to generate before proceeding.
+
+---
+
+### Step 3 — Generate the recipe scaffold
+
+For each approved recipe, generate ALL of the following files. Use the exact conventions from CLAUDE.md and the existing recipes in this repo. Generate complete, runnable files — not stubs.
+
+**File conventions:**
+- Directory: `{category}/{recipe-name}_python/`
+- Task queue: `{recipe-name}-task-queue`
+- Workflow class: `PascalCaseWorkflow`
+- Activity functions: `snake_case`
+- Request models: `ActivityNameRequest` (dataclass or Pydantic BaseModel)
+- LLM clients: always `max_retries=0`
+- Timeouts: `start_to_close_timeout=timedelta(seconds=30)` (adjust up for research tasks)
+- Data converter: `pydantic_data_converter` everywhere (Client.connect, WorkflowEnvironment)
+- Python version constraint: `>=3.10,<3.14`
+- Temporalio: `>=1.15.0,<2`
+
+**Files to generate:**
+
+#### `README.md`
+Must start with this exact front matter block:
+```
+<!--
+description: One-sentence description of what the recipe demonstrates.
+tags: [category, python, provider]
+priority: 500
+-->
+```
+Then: title, brief overview, what it demonstrates, how to run (uv sync, uv run python -m worker, uv run python -m start_workflow), what to expect in output.
+
+#### `pyproject.toml`
+- `name = "cookbook-{recipe-name}-python"`
+- `requires-python = ">=3.10,<3.14"`
+- `dependencies`: temporalio + the relevant LLM provider SDK
+- `[dependency-groups] dev`: pytest, pytest-timeout, pytest-asyncio
+- `[tool.pytest.ini_options] pythonpath = ["."]`
+
+#### `worker.py`
+- `Client.connect("localhost:7233", data_converter=pydantic_data_converter)`
+- `Worker(client, task_queue=..., workflows=[...], activities=[...])`
+- `asyncio.run(main())`
+
+#### `start_workflow.py`
+- Connect, execute_workflow, print result
+
+#### `workflows/{workflow_name}.py`
+- `@workflow.defn` class
+- `@workflow.run` async method
+- Activities called via `workflow.execute_activity`
+- Always specify `start_to_close_timeout`
+
+#### `activities/{activity_name}.py`
+- `@activity.defn` functions
+- LLM client with `max_retries=0`
+- Non-retryable errors raise `ApplicationError(..., non_retryable=True)`
+- Request model at top of file or in `activities/models.py`
+
+#### `tests/test_{recipe_name}.py`
+- `@pytest.mark.asyncio` + `@pytest.mark.timeout(30)` on all tests
+- `WorkflowEnvironment.start_time_skipping(data_converter=pydantic_data_converter)`
+- Mock activities using `unittest.mock.AsyncMock` or by injecting test doubles into the Worker
+- At minimum: one happy-path workflow test
+
+---
+
+### Step 4 — Write the files
+
+Create the directory and write all files. Then report:
+- What was created
+- How to run it: `cd {directory} && uv sync && uv run pytest tests/`
+- Any simplifications you made vs. the source project, and why
+- What a developer should modify to connect to real APIs (env vars needed, etc.)

--- a/.claude/commands/recipe-ify.md
+++ b/.claude/commands/recipe-ify.md
@@ -25,11 +25,20 @@ Look specifically for these **AI building block** patterns, which make strong re
 - **Agentic loop** — LLM called in a loop until a stop condition (tool use, stop sequence, empty tool calls)
 - **Forced completion** — On the final loop iteration, `tool_choice` is constrained to a specific tool so the agent must commit to a decision rather than looping forever
 - **Tool calling** — LLM invokes structured tools; results fed back into the conversation
-- **Multi-agent coordination** — One agent spawns or delegates to sub-agents; results are aggregated
+- **Parallel tool calls** — LLM requests multiple tools simultaneously; all results must be collected before the next turn
+- **Multi-agent coordination / agent supervisor** — One agent spawns or delegates to sub-agents; results are aggregated
 - **Structured output** — LLM output is parsed and validated against a Pydantic schema
 - **Human-in-the-loop** — Workflow pauses and waits for a human decision before continuing
+- **Streaming output** — Activity emits incremental tokens/chunks rather than waiting for full completion
+- **RAG (retrieval-augmented generation)** — Retrieved context injected into the prompt before calling the LLM
+- **Short-term memory** — Conversation history carried across turns within a single workflow run
+- **Long-term memory** — Facts or summaries persisted across workflow runs and retrieved on demand
+- **Context summarization** — Long conversation history compressed (e.g., via `continue_as_new`) to stay within context limits
+- **Guardrails** — LLM output checked against a policy before being acted on; rejected outputs are blocked or re-requested
+- **Chain-of-thought / tree-of-thought** — LLM explicitly reasons through steps before producing a final answer
 - **Prompt injection prevention** — Untrusted external data is isolated from control instructions (e.g., XML tags, separate message turns)
 - **Dynamic system prompts** — System instructions constructed at runtime from context (user prefs, retrieved docs, current state)
+- **Cost/token tracking** — Token usage recorded per workflow run for budgeting or rate-limiting
 - **Multi-provider LLM abstraction** — Single interface that dispatches to Anthropic, OpenAI, LiteLLM, or local models
 
 Ignore patterns that are primarily about Temporal internals (workflow ID policies, heartbeats, signal/query handlers, replay determinism) unless they are a natural, invisible part of an AI pattern above.
@@ -38,11 +47,25 @@ Ignore patterns that are primarily about Temporal internals (workflow ID policie
 
 ### Step 2 — Recommend which patterns to extract
 
+The cookbook has a wishlist of use cases not yet covered. Patterns that fill one of these gaps should be ranked higher:
+- RAG pipeline
+- Streaming output
+- Short-term or long-term memory
+- Context summarization (ContinueAsNew)
+- Agent supervisor / multi-agent swarm
+- Guardrails
+- Chain-of-thought / tree-of-thought
+- Cost/token tracking
+- Trigger-based AI (event-driven or timer-based)
+- Web crawler
+
 For each candidate pattern you find, evaluate:
 1. **Is it an AI building block?** Would an AI engineer immediately recognize this as a useful pattern for their LLM/agent work, independent of what orchestrator they use?
-2. **Is it self-contained?** Can it stand alone as a 200–400 line recipe without pulling in the entire project?
-3. **Is it teachable?** Does it demonstrate a single clear concept a developer can learn from?
-4. **Is it novel vs. existing recipes?** Check existing recipes in this repo (foundations/, agents/, deep_research/, mcp/) and flag if a very similar recipe already exists.
+2. **Is it well-engineered, not a demo?** The cookbook publishes reference-quality code, not flashy one-offs. Does the pattern reflect how a real production system would be built?
+3. **Is it self-contained?** Can it stand alone as a 200–400 line recipe without pulling in the entire project?
+4. **Is it teachable?** Does it demonstrate a single clear concept a developer can learn from?
+5. **Is it novel vs. existing recipes?** Check existing recipes in this repo (foundations/, agents/, deep_research/, mcp/) and flag if a very similar recipe already exists.
+6. **Does it fill a wishlist gap?** Cross-reference against the coverage wishlist above.
 
 Rank the top 2–4 patterns. For each, give:
 - A proposed recipe name (kebab-case, ending in `_python`)

--- a/.claude/commands/recipe-ify.md
+++ b/.claude/commands/recipe-ify.md
@@ -1,116 +1,50 @@
 # Recipe-ify
 
-Analyze an external project and generate a draft recipe (or multiple) for the ai-cookbook.
+Generate a complete, PR-ready recipe for the AI Cookbook from a pattern description.
 
-Usage: `/project:recipe-ify <github-url>`
+Usage: `/project:recipe-ify <pattern description or proposal card>`
+
+The input can be:
+- A proposal card from `/project:recipe-scout`
+- A freeform description ("generate a RAG pipeline recipe using OpenAI")
+- Anything in between
+
+---
 
 ## What you do
 
-You are an expert at extracting teachable, self-contained AI patterns from real-world projects and turning them into cookbook recipes in the exact format this repo uses.
+You are an expert at writing reference-quality AI Cookbook recipes. Generate ALL files for the recipe described in `$ARGUMENTS`, following the conventions below exactly. Produce complete, runnable files — not stubs or placeholders.
 
-**Audience reminder:** The AI Cookbook targets AI Engineers who are comfortable with LLMs and agents but are new to Temporal. Recipes should teach *AI building blocks* — patterns for how agents think, decide, call tools, and coordinate — with Temporal providing durability underneath. Do NOT extract patterns that are primarily about Temporal orchestration, distributed systems, or infrastructure; those belong in Temporal's own documentation, not here.
-
-Work through the following steps.
+**Audience reminder:** Recipes target AI Engineers who are comfortable with LLMs and agents but are new to Temporal. The AI pattern is the hero; Temporal is the invisible durability layer underneath. Don't over-explain Temporal mechanics — focus on making the AI concept clear.
 
 ---
 
-### Step 1 — Fetch and analyze the project
+## Cookbook conventions
 
-Fetch the repository at `$ARGUMENTS`. Collect:
-- The README (for intent and architecture overview)
-- The full file tree (via GitHub API: `https://api.github.com/repos/{owner}/{repo}/git/trees/main?recursive=1`)
-- Key source files: LLM integration code, agent/tool patterns, prompt construction, workflow definitions
+**Directory:** `{category}/{recipe-name}_python/`
+Categories: `foundations` (single LLM call or simple pattern), `agents` (agentic loops, tool use), `deep_research` (multi-agent), `mcp` (MCP servers)
 
-Look specifically for these **AI building block** patterns, which make strong recipes:
-- **Agentic loop** — LLM called in a loop until a stop condition (tool use, stop sequence, empty tool calls)
-- **Forced completion** — On the final loop iteration, `tool_choice` is constrained to a specific tool so the agent must commit to a decision rather than looping forever
-- **Tool calling** — LLM invokes structured tools; results fed back into the conversation
-- **Parallel tool calls** — LLM requests multiple tools simultaneously; all results must be collected before the next turn
-- **Multi-agent coordination / agent supervisor** — One agent spawns or delegates to sub-agents; results are aggregated
-- **Structured output** — LLM output is parsed and validated against a Pydantic schema
-- **Human-in-the-loop** — Workflow pauses and waits for a human decision before continuing
-- **Streaming output** — Activity emits incremental tokens/chunks rather than waiting for full completion
-- **RAG (retrieval-augmented generation)** — Retrieved context injected into the prompt before calling the LLM
-- **Short-term memory** — Conversation history carried across turns within a single workflow run
-- **Long-term memory** — Facts or summaries persisted across workflow runs and retrieved on demand
-- **Context summarization** — Long conversation history compressed (e.g., via `continue_as_new`) to stay within context limits
-- **Guardrails** — LLM output checked against a policy before being acted on; rejected outputs are blocked or re-requested
-- **Chain-of-thought / tree-of-thought** — LLM explicitly reasons through steps before producing a final answer
-- **Prompt injection prevention** — Untrusted external data is isolated from control instructions (e.g., XML tags, separate message turns)
-- **Dynamic system prompts** — System instructions constructed at runtime from context (user prefs, retrieved docs, current state)
-- **Cost/token tracking** — Token usage recorded per workflow run for budgeting or rate-limiting
-- **Multi-provider LLM abstraction** — Single interface that dispatches to Anthropic, OpenAI, LiteLLM, or local models
-
-Ignore patterns that are primarily about Temporal internals (workflow ID policies, heartbeats, signal/query handlers, replay determinism) unless they are a natural, invisible part of an AI pattern above.
-
----
-
-### Step 2 — Recommend which patterns to extract
-
-The cookbook has a wishlist of use cases not yet covered. Patterns that fill one of these gaps should be ranked higher:
-- RAG pipeline
-- Streaming output
-- Short-term or long-term memory
-- Context summarization (ContinueAsNew)
-- Agent supervisor / multi-agent swarm
-- Guardrails
-- Chain-of-thought / tree-of-thought
-- Cost/token tracking
-- Trigger-based AI (event-driven or timer-based)
-- Web crawler
-
-For each candidate pattern you find, evaluate:
-1. **Is it an AI building block?** Would an AI engineer immediately recognize this as a useful pattern for their LLM/agent work, independent of what orchestrator they use?
-2. **Is it well-engineered, not a demo?** The cookbook publishes reference-quality code, not flashy one-offs. Does the pattern reflect how a real production system would be built?
-3. **Is it self-contained?** Can it stand alone as a 200–400 line recipe without pulling in the entire project?
-4. **Is it teachable?** Does it demonstrate a single clear concept a developer can learn from?
-5. **Is it novel vs. existing recipes?** Check existing recipes in this repo (foundations/, agents/, deep_research/, mcp/) and flag if a very similar recipe already exists.
-6. **Does it fill a wishlist gap?** Cross-reference against the coverage wishlist above.
-
-Rank the top 2–4 patterns. For each, provide a proposal card with the following sections — written so a reviewer who has never seen the source project can evaluate it:
-
-**Proposed recipe:** `{category}/{recipe-name}_python`
-
-**One-line description:** _(the README front matter `description` field)_
-
-**The problem it solves:** In 2–3 sentences: what goes wrong if a developer doesn't know this pattern? What mistake do they typically make, and what does that cost them?
-
-**The pattern in the source:** A short code excerpt (10–25 lines) from the source project that shows the pattern at its clearest. If the source isn't Python or doesn't translate directly, describe the equivalent pseudocode. This is the "exhibit A" that justifies the recipe.
-
-**How the recipe would be structured:** A brief outline — what the workflow does, what the key activity does, what tool or API is involved. Not full code, just enough for a reviewer to picture the finished recipe. Should be 5–10 bullet points.
-
-**Closest existing recipe and what's different:** Name the most similar recipe already in the cookbook and state specifically what this recipe adds or changes. If there's no close match, say so.
-
-**Wishlist gap filled:** Which item from the coverage wishlist does this address, if any? If none, say so.
-
-**Estimated size:** Rough line count for the finished recipe (all files combined). Flag anything over 400 lines as potentially too complex for a single recipe.
-
-If a pattern you found is interesting but primarily a Temporal/infrastructure concern rather than an AI building block, list it in a separate "Excluded patterns" section with a one-line reason for each.
-
-Ask the user which recipe(s) to generate before proceeding.
-
----
-
-### Step 3 — Generate the recipe scaffold
-
-For each approved recipe, generate ALL of the following files. Use the exact conventions from CLAUDE.md and the existing recipes in this repo. Generate complete, runnable files — not stubs.
-
-**File conventions:**
-- Directory: `{category}/{recipe-name}_python/`
+**Naming:**
 - Task queue: `{recipe-name}-task-queue`
 - Workflow class: `PascalCaseWorkflow`
 - Activity functions: `snake_case`
-- Request models: `ActivityNameRequest` (dataclass or Pydantic BaseModel)
-- LLM clients: always `max_retries=0`
-- Timeouts: `start_to_close_timeout=timedelta(seconds=30)` (adjust up for research tasks)
-- Data converter: `pydantic_data_converter` everywhere (Client.connect, WorkflowEnvironment)
-- Python version constraint: `>=3.10,<3.14`
+- Request/response models: `ActivityNameRequest`, `ActivityNameResponse`
+
+**Always:**
+- LLM clients: `max_retries=0` — Temporal handles retries, not the client
+- Data converter: `pydantic_data_converter` everywhere — in `Client.connect()`, in `WorkflowEnvironment.start_time_skipping()`
+- Activity timeouts: always specify `start_to_close_timeout` (30s default; increase for research/LLM tasks)
+- Non-retryable errors: catch them and raise `ApplicationError(..., non_retryable=True)`
+- Python: `>=3.10,<3.14`
 - Temporalio: `>=1.15.0,<2`
 
-**Files to generate:**
+---
 
-#### `README.md`
-Must start with this exact front matter block:
+## Files to generate
+
+### `README.md`
+
+Must open with this exact front matter block:
 ```
 <!--
 description: One-sentence description of what the recipe demonstrates.
@@ -118,47 +52,81 @@ tags: [category, python, provider]
 priority: 500
 -->
 ```
-Then: title, brief overview, what it demonstrates, how to run (uv sync, uv run python -m worker, uv run python -m start_workflow), what to expect in output.
+Then: title, 1–2 paragraph overview of what the recipe teaches, prerequisites, how to run:
+```
+uv sync
+uv run python -m worker        # terminal 1
+uv run python -m start_workflow  # terminal 2
+```
+End with what to expect in the output.
 
-#### `pyproject.toml`
-- `name = "cookbook-{recipe-name}-python"`
-- `requires-python = ">=3.10,<3.14"`
-- `dependencies`: temporalio + the relevant LLM provider SDK
-- `[dependency-groups] dev`: pytest, pytest-timeout, pytest-asyncio
-- `[tool.pytest.ini_options] pythonpath = ["."]`
+### `pyproject.toml`
+```toml
+[project]
+name = "cookbook-{recipe-name}-python"
+version = "0.1"
+description = "..."
+authors = [{ name = "Temporal Technologies Inc", email = "sdk@temporal.io" }]
+requires-python = ">=3.10,<3.14"
+readme = "README.md"
+license = "MIT"
+dependencies = [
+    "temporalio>=1.15.0,<2",
+    # LLM provider SDK
+]
 
-#### `worker.py`
-- `Client.connect("localhost:7233", data_converter=pydantic_data_converter)`
-- `Worker(client, task_queue=..., workflows=[...], activities=[...])`
-- `asyncio.run(main())`
+[dependency-groups]
+dev = [
+    "pytest>=9.0.3",
+    "pytest-timeout>=2.4.0",
+    "pytest-asyncio>=0.26.0",
+]
 
-#### `start_workflow.py`
-- Connect, execute_workflow, print result
+[tool.pytest.ini_options]
+pythonpath = ["."]
+```
 
-#### `workflows/{workflow_name}.py`
-- `@workflow.defn` class
-- `@workflow.run` async method
-- Activities called via `workflow.execute_activity`
-- Always specify `start_to_close_timeout`
+### `worker.py`
+```python
+import asyncio
+from temporalio.client import Client
+from temporalio.worker import Worker
+from temporalio.contrib.pydantic import pydantic_data_converter
 
-#### `activities/{activity_name}.py`
+async def main():
+    client = await Client.connect("localhost:7233", data_converter=pydantic_data_converter)
+    worker = Worker(client, task_queue="...-task-queue", workflows=[...], activities=[...])
+    await worker.run()
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+### `start_workflow.py`
+Connect with `pydantic_data_converter`, call `execute_workflow`, print result.
+
+### `workflows/{name}.py`
+- `@workflow.defn` class with `@workflow.run` method
+- Calls activities via `workflow.execute_activity(fn, request, start_to_close_timeout=...)`
+- Pure orchestration — no LLM calls, no I/O
+
+### `activities/{name}.py`
 - `@activity.defn` functions
-- LLM client with `max_retries=0`
-- Non-retryable errors raise `ApplicationError(..., non_retryable=True)`
-- Request model at top of file or in `activities/models.py`
+- LLM client initialized with `max_retries=0`
+- Request model defined at top of file (dataclass or Pydantic `BaseModel`)
+- Catch non-retryable API errors → `ApplicationError(..., non_retryable=True)`
 
-#### `tests/test_{recipe_name}.py`
-- `@pytest.mark.asyncio` + `@pytest.mark.timeout(30)` on all tests
-- `WorkflowEnvironment.start_time_skipping(data_converter=pydantic_data_converter)`
-- Mock activities using `unittest.mock.AsyncMock` or by injecting test doubles into the Worker
-- At minimum: one happy-path workflow test
+### `tests/test_{name}.py`
+- `@pytest.mark.asyncio` and `@pytest.mark.timeout(30)` on every test
+- Use `WorkflowEnvironment.start_time_skipping(data_converter=pydantic_data_converter)`
+- Register mock activities in the Worker to avoid real API calls
+- Cover at minimum: happy path, and the key edge case the recipe is about
 
 ---
 
-### Step 4 — Write the files
+## After generating files
 
-Create the directory and write all files. Then report:
-- What was created
-- How to run it: `cd {directory} && uv sync && uv run pytest tests/`
-- Any simplifications you made vs. the source project, and why
-- What a developer should modify to connect to real APIs (env vars needed, etc.)
+1. Report what was created and the directory path
+2. Show how to run: `cd {dir} && uv sync && uv run pytest tests/`
+3. List any env vars needed (API keys, etc.) and where to set them
+4. Note any deliberate simplifications made to keep the recipe bite-sized

--- a/.claude/commands/recipe-ify.md
+++ b/.claude/commands/recipe-ify.md
@@ -6,7 +6,11 @@ Usage: `/project:recipe-ify <github-url>`
 
 ## What you do
 
-You are an expert at extracting teachable, self-contained patterns from real-world AI projects and turning them into cookbook recipes in the exact format this repo uses. Work through the following steps.
+You are an expert at extracting teachable, self-contained AI patterns from real-world projects and turning them into cookbook recipes in the exact format this repo uses.
+
+**Audience reminder:** The AI Cookbook targets AI Engineers who are comfortable with LLMs and agents but are new to Temporal. Recipes should teach *AI building blocks* — patterns for how agents think, decide, call tools, and coordinate — with Temporal providing durability underneath. Do NOT extract patterns that are primarily about Temporal orchestration, distributed systems, or infrastructure; those belong in Temporal's own documentation, not here.
+
+Work through the following steps.
 
 ---
 
@@ -15,36 +19,39 @@ You are an expert at extracting teachable, self-contained patterns from real-wor
 Fetch the repository at `$ARGUMENTS`. Collect:
 - The README (for intent and architecture overview)
 - The full file tree (via GitHub API: `https://api.github.com/repos/{owner}/{repo}/git/trees/main?recursive=1`)
-- Key source files: workflow definitions, activity implementations, LLM integration code, any agent/tool patterns
+- Key source files: LLM integration code, agent/tool patterns, prompt construction, workflow definitions
 
-Look specifically for these patterns, which make strong recipes:
-- **Agentic loops** — LLM calls in a loop until stop condition (tool use, stop sequence, empty choices)
-- **Forced completion** — Constraining tool choice on the final loop iteration to force a decision
-- **Parallel activities** — Multiple independent async activities launched concurrently with `asyncio.gather`
-- **Graceful degradation** — Activities that catch their own failures and return defaults rather than propagating
-- **Workflow deduplication** — Using a deterministic workflow ID as a cache/dedup key across triggers
-- **Prompt caching** — `cache_control: ephemeral` or equivalent to amortize repeated system prompts
-- **Structured output validation** — LLM outputs validated through a Pydantic schema
-- **Human-in-the-loop** — Workflow pauses awaiting a signal or external approval
-- **Prompt injection prevention** — Untrusted data isolated from control instructions via XML tags or similar
-- **Multi-provider abstraction** — Single interface dispatching to Anthropic, OpenAI, LiteLLM, etc.
-- **Signal/Query handlers** — Workflows that expose runtime state or accept commands
+Look specifically for these **AI building block** patterns, which make strong recipes:
+- **Agentic loop** — LLM called in a loop until a stop condition (tool use, stop sequence, empty tool calls)
+- **Forced completion** — On the final loop iteration, `tool_choice` is constrained to a specific tool so the agent must commit to a decision rather than looping forever
+- **Tool calling** — LLM invokes structured tools; results fed back into the conversation
+- **Multi-agent coordination** — One agent spawns or delegates to sub-agents; results are aggregated
+- **Structured output** — LLM output is parsed and validated against a Pydantic schema
+- **Human-in-the-loop** — Workflow pauses and waits for a human decision before continuing
+- **Prompt injection prevention** — Untrusted external data is isolated from control instructions (e.g., XML tags, separate message turns)
+- **Dynamic system prompts** — System instructions constructed at runtime from context (user prefs, retrieved docs, current state)
+- **Multi-provider LLM abstraction** — Single interface that dispatches to Anthropic, OpenAI, LiteLLM, or local models
+
+Ignore patterns that are primarily about Temporal internals (workflow ID policies, heartbeats, signal/query handlers, replay determinism) unless they are a natural, invisible part of an AI pattern above.
 
 ---
 
 ### Step 2 — Recommend which patterns to extract
 
 For each candidate pattern you find, evaluate:
-1. **Is it self-contained?** Can it stand alone as a 200–400 line recipe without pulling in the entire project?
-2. **Is it teachable?** Does it demonstrate a single clear concept a developer can learn from?
-3. **Is it novel vs. existing recipes?** Check existing recipes in this repo (foundations/, agents/, deep_research/, mcp/) and flag if a very similar recipe already exists.
+1. **Is it an AI building block?** Would an AI engineer immediately recognize this as a useful pattern for their LLM/agent work, independent of what orchestrator they use?
+2. **Is it self-contained?** Can it stand alone as a 200–400 line recipe without pulling in the entire project?
+3. **Is it teachable?** Does it demonstrate a single clear concept a developer can learn from?
+4. **Is it novel vs. existing recipes?** Check existing recipes in this repo (foundations/, agents/, deep_research/, mcp/) and flag if a very similar recipe already exists.
 
 Rank the top 2–4 patterns. For each, give:
 - A proposed recipe name (kebab-case, ending in `_python`)
 - A proposed category (foundations, agents, deep_research, or mcp)
 - A one-sentence description for the README front matter
 - The key files from the source project that the recipe would draw from
-- Why this pattern matters / what a developer learns from it
+- The AI concept the developer learns — framed for someone who knows LLMs but not Temporal
+
+If a pattern you found is interesting but primarily a Temporal/infrastructure concern rather than an AI building block, note it briefly and explain why it was excluded.
 
 Ask the user which recipe(s) to generate before proceeding.
 

--- a/.claude/commands/recipe-scout.md
+++ b/.claude/commands/recipe-scout.md
@@ -1,0 +1,90 @@
+# Recipe Scout
+
+Analyze an external project and identify which parts would make good AI Cookbook recipes.
+
+Usage: `/project:recipe-scout <github-url>`
+
+## What you do
+
+You are an expert at spotting teachable, self-contained AI patterns in real-world projects. Your job is to produce proposal cards that a reviewer — who may never have seen the source project — can use to decide what's worth building into a recipe.
+
+**Audience reminder:** The AI Cookbook targets AI Engineers who are comfortable with LLMs and agents but are new to Temporal. Recipes should teach *AI building blocks* — patterns for how agents think, decide, call tools, and coordinate — with Temporal providing durability underneath. Do NOT propose patterns that are primarily about Temporal orchestration, distributed systems, or infrastructure; those belong in Temporal's own documentation, not here.
+
+---
+
+### Step 1 — Fetch and analyze the project
+
+Fetch the repository at `$ARGUMENTS`. Collect:
+- The README (for intent and architecture overview)
+- The full file tree (via GitHub API: `https://api.github.com/repos/{owner}/{repo}/git/trees/main?recursive=1`)
+- Key source files: LLM integration code, agent/tool patterns, prompt construction, workflow definitions
+
+Look specifically for these **AI building block** patterns, which make strong recipes:
+- **Agentic loop** — LLM called in a loop until a stop condition (tool use, stop sequence, empty tool calls)
+- **Forced completion** — On the final loop iteration, `tool_choice` is constrained to a specific tool so the agent must commit to a decision rather than looping forever
+- **Tool calling** — LLM invokes structured tools; results fed back into the conversation
+- **Parallel tool calls** — LLM requests multiple tools simultaneously; all results must be collected before the next turn
+- **Multi-agent coordination / agent supervisor** — One agent spawns or delegates to sub-agents; results are aggregated
+- **Structured output** — LLM output is parsed and validated against a Pydantic schema
+- **Human-in-the-loop** — Workflow pauses and waits for a human decision before continuing
+- **Streaming output** — Activity emits incremental tokens/chunks rather than waiting for full completion
+- **RAG (retrieval-augmented generation)** — Retrieved context injected into the prompt before calling the LLM
+- **Short-term memory** — Conversation history carried across turns within a single workflow run
+- **Long-term memory** — Facts or summaries persisted across workflow runs and retrieved on demand
+- **Context summarization** — Long conversation history compressed (e.g., via `continue_as_new`) to stay within context limits
+- **Guardrails** — LLM output checked against a policy before being acted on; rejected outputs are blocked or re-requested
+- **Chain-of-thought / tree-of-thought** — LLM explicitly reasons through steps before producing a final answer
+- **Prompt injection prevention** — Untrusted external data is isolated from control instructions (e.g., XML tags, separate message turns)
+- **Dynamic system prompts** — System instructions constructed at runtime from context (user prefs, retrieved docs, current state)
+- **Cost/token tracking** — Token usage recorded per workflow run for budgeting or rate-limiting
+- **Multi-provider LLM abstraction** — Single interface that dispatches to Anthropic, OpenAI, LiteLLM, or local models
+
+Ignore patterns that are primarily about Temporal internals (workflow ID policies, heartbeats, signal/query handlers, replay determinism) unless they are a natural, invisible part of an AI pattern above.
+
+---
+
+### Step 2 — Produce proposal cards
+
+The cookbook has a wishlist of use cases not yet covered. Patterns that fill one of these gaps should be ranked higher:
+- RAG pipeline
+- Streaming output
+- Short-term or long-term memory
+- Context summarization (ContinueAsNew)
+- Agent supervisor / multi-agent swarm
+- Guardrails
+- Chain-of-thought / tree-of-thought
+- Cost/token tracking
+- Trigger-based AI (event-driven or timer-based)
+- Web crawler
+
+For each candidate pattern you find, evaluate:
+1. **Is it an AI building block?** Would an AI engineer recognize this as a useful pattern for their LLM/agent work, independent of what orchestrator they use?
+2. **Is it well-engineered, not a demo?** The cookbook publishes reference-quality code, not flashy one-offs.
+3. **Is it self-contained?** Can it stand alone as a 200–400 line recipe without pulling in the entire project?
+4. **Is it teachable?** Does it demonstrate a single clear concept a developer can learn from?
+5. **Is it novel vs. existing recipes?** Check existing recipes in this repo (foundations/, agents/, deep_research/, mcp/).
+6. **Does it fill a wishlist gap?** Cross-reference against the coverage wishlist above.
+
+Rank the top 2–4 patterns. For each, write a proposal card with the following sections — written so a reviewer who has never seen the source project can evaluate it:
+
+**Proposed recipe:** `{category}/{recipe-name}_python`
+
+**One-line description:** _(the README front matter `description` field)_
+
+**The problem it solves:** In 2–3 sentences: what goes wrong if a developer doesn't know this pattern? What mistake do they typically make, and what does that cost them?
+
+**The pattern in the source:** A short code excerpt (10–25 lines) from the source project that shows the pattern at its clearest. If the source isn't Python or doesn't translate directly, show equivalent pseudocode. This is the "exhibit A" that justifies the recipe.
+
+**How the recipe would be structured:** A brief outline — what the workflow does, what the key activity does, what tool or API is involved. Not full code, 5–10 bullet points.
+
+**Closest existing recipe and what's different:** Name the most similar recipe already in the cookbook and state specifically what this adds or changes. If there's no close match, say so.
+
+**Wishlist gap filled:** Which item from the coverage wishlist does this address, if any? If none, say so.
+
+**Estimated size:** Rough line count for the finished recipe (all files combined). Flag anything over 400 lines as potentially too complex for a single recipe.
+
+---
+
+After the proposal cards, add an **Excluded patterns** section listing any patterns that were interesting but filtered out, with a one-line reason for each.
+
+To generate a recipe from one of these proposals, use `/project:recipe-ify` and paste in the proposal card.


### PR DESCRIPTION
## Summary

- Adds `.claude/commands/recipe-ify.md`, a Claude Code slash command for turning external AI projects into cookbook recipes
- Invoke with `/project:recipe-ify <github-url>` — it fetches the repo, identifies teachable patterns, proposes the top candidates, and generates complete recipe scaffolds (all files, runnable, not stubs)

## What the command does

1. **Fetches & analyzes** the target repo — README, file tree, workflow/activity/LLM code
2. **Scores patterns** against a checklist (agentic loops, forced completion, workflow dedup, graceful degradation, prompt caching, structured output, human-in-the-loop, etc.) for self-containedness and novelty vs. existing recipes
3. **Proposes** 2–4 recipes with names, categories, descriptions, and rationale — pauses for approval
4. **Generates** all files: `README.md` (with required front matter), `pyproject.toml`, `worker.py`, `start_workflow.py`, `workflows/`, `activities/`, `tests/` — following all conventions from `CLAUDE.md`

## Test plan

- [ ] Run `/project:recipe-ify https://github.com/temporal-community/dependency-scout` and verify it proposes reasonable recipes
- [ ] Approve one recipe and verify the generated files follow cookbook conventions (front matter, `max_retries=0`, `pydantic_data_converter`, etc.)
- [ ] Run `uv sync && uv run pytest tests/ --timeout=30` in the generated recipe directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)