### PR TITLE
Fix & simplify Dependency Scout triage (embedded --local mode)

### DIFF
--- a/.github/workflows/dependabot-triage.yml
+++ b/.github/workflows/dependabot-triage.yml
@@ -20,85 +20,38 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - name: Checkout dependency-scout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-        with:
-          repository: temporal-community/dependency-scout
-
       - name: Setup uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
 
-      - name: Install dependencies
-        run: uv sync
-
-      # --- Temporal connection: local dev server (no secrets needed) -----------
-      - name: Install Temporal CLI
-        if: secrets.TEMPORAL_ADDRESS == ''
-        run: curl -sSf https://temporal.download/cli.sh | sh
-
-      - name: Start local Temporal server
-        if: secrets.TEMPORAL_ADDRESS == ''
-        run: |
-          temporal server start-dev --headless &
-          sleep 5
-
-      # --- Temporal connection: Temporal Cloud (when secrets are configured) ---
-      - name: Write Temporal Cloud TLS certificates
-        if: secrets.TEMPORAL_ADDRESS != ''
-        run: |
-          echo "${{ secrets.TEMPORAL_CLIENT_CERT }}" > /tmp/temporal-client.pem
-          echo "${{ secrets.TEMPORAL_CLIENT_KEY }}" > /tmp/temporal-client.key
-          chmod 600 /tmp/temporal-client.pem /tmp/temporal-client.key
-
-      # -------------------------------------------------------------------------
-      - name: Start worker
-        env:
-          TEMPORAL_ADDRESS: ${{ secrets.TEMPORAL_ADDRESS || 'localhost:7233' }}
-          TEMPORAL_NAMESPACE: ${{ secrets.TEMPORAL_NAMESPACE || 'default' }}
-          TEMPORAL_TLS_CERT: ${{ secrets.TEMPORAL_ADDRESS != '' && '/tmp/temporal-client.pem' || '' }}
-          TEMPORAL_TLS_KEY: ${{ secrets.TEMPORAL_ADDRESS != '' && '/tmp/temporal-client.key' || '' }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-        run: |
-          uv run python -m worker &
-          echo "WORKER_PID=$!" >> "$GITHUB_ENV"
-          sleep 5
+      # dependency-scout runs fully self-contained via `--local`: it boots an
+      # ephemeral in-process Temporal server + worker for the single invocation,
+      # so there's no source checkout, no Temporal CLI, and no worker process to
+      # manage. The verdict comment / merge / close behavior is controlled by
+      # .github/dependency-scout.yml in this repo.
 
       - name: Triage PR (event-triggered)
         if: github.event_name == 'pull_request_target'
         env:
-          TEMPORAL_ADDRESS: ${{ secrets.TEMPORAL_ADDRESS || 'localhost:7233' }}
-          TEMPORAL_NAMESPACE: ${{ secrets.TEMPORAL_NAMESPACE || 'default' }}
-          TEMPORAL_TLS_CERT: ${{ secrets.TEMPORAL_ADDRESS != '' && '/tmp/temporal-client.pem' || '' }}
-          TEMPORAL_TLS_KEY: ${{ secrets.TEMPORAL_ADDRESS != '' && '/tmp/temporal-client.key' || '' }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          uv run dependency-scout triage "${{ github.event.pull_request.html_url }}"
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: >
+          uvx --from "git+https://github.com/temporal-community/dependency-scout@main"
+          dependency-scout triage "${{ github.event.pull_request.html_url }}" --local
 
       - name: Triage PR (manual — specific URL)
         if: github.event_name == 'workflow_dispatch' && inputs.pr_url != ''
         env:
-          TEMPORAL_ADDRESS: ${{ secrets.TEMPORAL_ADDRESS || 'localhost:7233' }}
-          TEMPORAL_NAMESPACE: ${{ secrets.TEMPORAL_NAMESPACE || 'default' }}
-          TEMPORAL_TLS_CERT: ${{ secrets.TEMPORAL_ADDRESS != '' && '/tmp/temporal-client.pem' || '' }}
-          TEMPORAL_TLS_KEY: ${{ secrets.TEMPORAL_ADDRESS != '' && '/tmp/temporal-client.key' || '' }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          uv run dependency-scout triage "${{ inputs.pr_url }}"
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: >
+          uvx --from "git+https://github.com/temporal-community/dependency-scout@main"
+          dependency-scout triage "${{ inputs.pr_url }}" --local
 
       - name: Triage all open Dependabot PRs (manual — no URL given)
         if: github.event_name == 'workflow_dispatch' && inputs.pr_url == ''
         env:
-          TEMPORAL_ADDRESS: ${{ secrets.TEMPORAL_ADDRESS || 'localhost:7233' }}
-          TEMPORAL_NAMESPACE: ${{ secrets.TEMPORAL_NAMESPACE || 'default' }}
-          TEMPORAL_TLS_CERT: ${{ secrets.TEMPORAL_ADDRESS != '' && '/tmp/temporal-client.pem' || '' }}
-          TEMPORAL_TLS_KEY: ${{ secrets.TEMPORAL_ADDRESS != '' && '/tmp/temporal-client.key' || '' }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          uv run dependency-scout triage --repo temporalio/ai-cookbook
-
-      - name: Stop worker
-        if: always()
-        run: |
-          kill "$WORKER_PID" 2>/dev/null || true
-          rm -f /tmp/temporal-client.pem /tmp/temporal-client.key
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: >
+          uvx --from "git+https://github.com/temporal-community/dependency-scout@main"
+          dependency-scout triage --repo temporalio/ai-cookbook --local

--- a/.github/workflows/dependabot-triage.yml
+++ b/.github/workflows/dependabot-triage.yml
@@ -28,24 +28,28 @@ jobs:
       # so there's no source checkout, no Temporal CLI, and no worker process to
       # manage. The verdict comment / merge / close behavior is controlled by
       # .github/dependency-scout.yml in this repo.
+      #
+      # NOTE: --dry-run is enabled below so the first runs only log verdicts
+      # (no comments, merges, or closes). Once the verdicts look right, remove
+      # --dry-run from the three steps to let it act.
 
       - name: Triage PR (event-triggered)
         if: github.event_name == 'pull_request_target'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-        run: uvx 'dependency-scout>=0.2.0' triage "${{ github.event.pull_request.html_url }}" --local
+        run: uvx 'dependency-scout>=0.2.0' triage "${{ github.event.pull_request.html_url }}" --local --dry-run
 
       - name: Triage PR (manual — specific URL)
         if: github.event_name == 'workflow_dispatch' && inputs.pr_url != ''
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-        run: uvx 'dependency-scout>=0.2.0' triage "${{ inputs.pr_url }}" --local
+        run: uvx 'dependency-scout>=0.2.0' triage "${{ inputs.pr_url }}" --local --dry-run
 
       - name: Triage all open Dependabot PRs (manual — no URL given)
         if: github.event_name == 'workflow_dispatch' && inputs.pr_url == ''
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-        run: uvx 'dependency-scout>=0.2.0' triage --repo temporalio/ai-cookbook --local
+        run: uvx 'dependency-scout>=0.2.0' triage --repo temporalio/ai-cookbook --local --dry-run

--- a/.github/workflows/dependabot-triage.yml
+++ b/.github/workflows/dependabot-triage.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
 
-      # dependency-scout runs fully self-contained via `--local`: it boots an
+      # Installed from PyPI; `--local` makes it fully self-contained — it boots an
       # ephemeral in-process Temporal server + worker for the single invocation,
       # so there's no source checkout, no Temporal CLI, and no worker process to
       # manage. The verdict comment / merge / close behavior is controlled by
@@ -34,24 +34,18 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-        run: >
-          uvx --from "git+https://github.com/temporal-community/dependency-scout@main"
-          dependency-scout triage "${{ github.event.pull_request.html_url }}" --local
+        run: uvx 'dependency-scout>=0.2.0' triage "${{ github.event.pull_request.html_url }}" --local
 
       - name: Triage PR (manual — specific URL)
         if: github.event_name == 'workflow_dispatch' && inputs.pr_url != ''
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-        run: >
-          uvx --from "git+https://github.com/temporal-community/dependency-scout@main"
-          dependency-scout triage "${{ inputs.pr_url }}" --local
+        run: uvx 'dependency-scout>=0.2.0' triage "${{ inputs.pr_url }}" --local
 
       - name: Triage all open Dependabot PRs (manual — no URL given)
         if: github.event_name == 'workflow_dispatch' && inputs.pr_url == ''
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-        run: >
-          uvx --from "git+https://github.com/temporal-community/dependency-scout@main"
-          dependency-scout triage --repo temporalio/ai-cookbook --local
+        run: uvx 'dependency-scout>=0.2.0' triage --repo temporalio/ai-cookbook --local


### PR DESCRIPTION
## The bug (why Dependabot PRs are piling up)

The `dependabot-triage.yml` workflow has been **failing at 0s on every Dependabot PR** — "This run likely failed because of a workflow file issue." The cause: it references the `secrets` context inside step-level `if:` conditions (e.g. `if: secrets.TEMPORAL_ADDRESS == ''`), which GitHub Actions does **not** allow. The whole workflow fails to evaluate, so triage never runs.

[Recent runs](https://github.com/temporalio/ai-cookbook/actions/workflows/dependabot-triage.yml) — all failures, all 0s.

## The fix

Rewrite the workflow to dependency-scout's new embedded **`--local`** mode, which boots an ephemeral in-process Temporal server + worker for the single invocation. This removes all the moving parts that the old workflow hand-rolled:

- ❌ checkout of `temporal-community/dependency-scout`
- ❌ `uv sync`
- ❌ Temporal CLI install + `temporal server start-dev`
- ❌ TLS cert writing
- ❌ worker start/stop
- ❌ the invalid `secrets.*`-in-`if:` conditions (the actual bug)

…all collapse into a single `uvx … dependency-scout triage … --local` call per trigger.

Triggers are unchanged: per-PR via `pull_request_target` (Dependabot only), plus `workflow_dispatch` for a specific URL or a full sweep of open PRs. Comment/merge/close behavior is still driven by `.github/dependency-scout.yml` (auto-merge on GREEN ≥0.90 confidence, block RED, request review from @webchick).

## Dependencies / sequencing

- Uses `uvx --from "git+…dependency-scout@main"`, so it works as soon as the upstream PR lands on `main`: **temporal-community/dependency-scout#3** (adds `--local`; also fixes a Socket.dev NDJSON crash that would otherwise fail triage when `SOCKET_API_KEY` is set). Merge that first.
- Once dependency-scout cuts a PyPI release including `--local`, this can be simplified further to plain `uvx dependency-scout …` (faster cold start, no per-run build).

## Note

`.github/dependency-scout.yml` has `auto_merge_enabled: true`. Since the workflow has been fully broken, this PR will be the first time triage actually acts on PRs. If you'd prefer to watch a few verdicts first, add `--dry-run` to the triage steps (or flip `auto_merge_enabled: false`) before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)