### PR TITLE
Update dependency-scout to >=0.2.2 + wire NVD/Socket keys

### DIFF
--- a/.github/workflows/dependabot-triage.yml
+++ b/.github/workflows/dependabot-triage.yml
@@ -38,18 +38,24 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-        run: uvx 'dependency-scout>=0.2.0' triage "${{ github.event.pull_request.html_url }}" --local --dry-run
+          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
+          SOCKET_API_KEY: ${{ secrets.SOCKET_API_KEY }}
+        run: uvx 'dependency-scout>=0.2.2' triage "${{ github.event.pull_request.html_url }}" --local --dry-run
 
       - name: Triage PR (manual — specific URL)
         if: github.event_name == 'workflow_dispatch' && inputs.pr_url != ''
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-        run: uvx 'dependency-scout>=0.2.0' triage "${{ inputs.pr_url }}" --local --dry-run
+          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
+          SOCKET_API_KEY: ${{ secrets.SOCKET_API_KEY }}
+        run: uvx 'dependency-scout>=0.2.2' triage "${{ inputs.pr_url }}" --local --dry-run
 
       - name: Triage all open Dependabot PRs (manual — no URL given)
         if: github.event_name == 'workflow_dispatch' && inputs.pr_url == ''
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-        run: uvx 'dependency-scout>=0.2.0' triage --repo temporalio/ai-cookbook --local --dry-run
+          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
+          SOCKET_API_KEY: ${{ secrets.SOCKET_API_KEY }}
+        run: uvx 'dependency-scout>=0.2.2' triage --repo temporalio/ai-cookbook --local --dry-run


### PR DESCRIPTION
Bumps the triage pin to **>=0.2.2** and wires the `NVD_API_KEY` / `SOCKET_API_KEY` secrets into all three triage steps.

0.2.2 brings graceful degradation for Anthropic billing/credit errors and structural triage resilience (a failing check — paid or not — degrades instead of sinking the run). Supersedes #156 (folds its key wiring in).

Still `--dry-run` (observe-only). The `NVD_API_KEY` and `SOCKET_API_KEY` repo secrets are already set, so those signals activate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)