### PR TITLE
Go live: dependency-scout acts on Dependabot PRs (drop --dry-run)

### DIFF
--- a/.github/workflows/dependabot-triage.yml
+++ b/.github/workflows/dependabot-triage.yml
@@ -28,10 +28,6 @@ jobs:
       # so there's no source checkout, no Temporal CLI, and no worker process to
       # manage. The verdict comment / merge / close behavior is controlled by
       # .github/dependency-scout.yml in this repo.
-      #
-      # NOTE: --dry-run is enabled below so the first runs only log verdicts
-      # (no comments, merges, or closes). Once the verdicts look right, remove
-      # --dry-run from the three steps to let it act.
 
       - name: Triage PR (event-triggered)
         if: github.event_name == 'pull_request_target'
@@ -40,7 +36,7 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
           SOCKET_API_KEY: ${{ secrets.SOCKET_API_KEY }}
-        run: uvx 'dependency-scout>=0.2.2' triage "${{ github.event.pull_request.html_url }}" --local --dry-run
+        run: uvx 'dependency-scout>=0.5.0' triage "${{ github.event.pull_request.html_url }}" --local
 
       - name: Triage PR (manual — specific URL)
         if: github.event_name == 'workflow_dispatch' && inputs.pr_url != ''
@@ -49,7 +45,7 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
           SOCKET_API_KEY: ${{ secrets.SOCKET_API_KEY }}
-        run: uvx 'dependency-scout>=0.2.2' triage "${{ inputs.pr_url }}" --local --dry-run
+        run: uvx 'dependency-scout>=0.5.0' triage "${{ inputs.pr_url }}" --local
 
       - name: Triage all open Dependabot PRs (manual — no URL given)
         if: github.event_name == 'workflow_dispatch' && inputs.pr_url == ''
@@ -58,4 +54,4 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
           SOCKET_API_KEY: ${{ secrets.SOCKET_API_KEY }}
-        run: uvx 'dependency-scout>=0.2.2' triage --repo temporalio/ai-cookbook --local --dry-run
+        run: uvx 'dependency-scout>=0.5.0' triage --repo temporalio/ai-cookbook --local


### PR DESCRIPTION
Removes `--dry-run` so the Scout takes action, and pins `dependency-scout>=0.5.0`.

Based on the dry-run sweeps, on the current backlog this will:
- 🟢 **auto-merge**: litellm, cryptography, pyjwt (low-risk patch/minor bumps the LLM cleared)
- 🟡 **request review** (@webchick): actions/checkout (major 4→6), astral-sh/setup-uv (held below the 0.90 auto-merge confidence)
- 🔴 **close**: starlette 0.50→1.0.1 (still has 4 CVEs; comment recommends ≥1.3.1)

Behavior is governed by `.github/dependency-scout.yml` (auto_merge_enabled, min_confidence 0.90, block [red], reviewers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)