### PR TITLE
Adopt dependency-scout 0.8.0: verdict labels + human-merge

### DIFF
--- a/.github/dependency-scout.yml
+++ b/.github/dependency-scout.yml
@@ -1,4 +1,4 @@
-auto_merge_enabled: true
+auto_merge_enabled: false
 auto_merge_min_confidence: 0.90
 min_release_age_hours: 168
 block_classifications: [red]

--- a/.github/workflows/dependabot-triage.yml
+++ b/.github/workflows/dependabot-triage.yml
@@ -36,7 +36,7 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
           SOCKET_API_KEY: ${{ secrets.SOCKET_API_KEY }}
-        run: uvx 'dependency-scout>=0.7.0' triage "${{ github.event.pull_request.html_url }}" --local
+        run: uvx 'dependency-scout>=0.8.0' triage "${{ github.event.pull_request.html_url }}" --local
 
       - name: Triage PR (manual — specific URL)
         if: github.event_name == 'workflow_dispatch' && inputs.pr_url != ''
@@ -45,7 +45,7 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
           SOCKET_API_KEY: ${{ secrets.SOCKET_API_KEY }}
-        run: uvx 'dependency-scout>=0.7.0' triage "${{ inputs.pr_url }}" --local
+        run: uvx 'dependency-scout>=0.8.0' triage "${{ inputs.pr_url }}" --local
 
       - name: Triage all open Dependabot PRs (manual — no URL given)
         if: github.event_name == 'workflow_dispatch' && inputs.pr_url == ''
@@ -54,4 +54,4 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
           SOCKET_API_KEY: ${{ secrets.SOCKET_API_KEY }}
-        run: uvx 'dependency-scout>=0.7.0' triage --repo temporalio/ai-cookbook --local
+        run: uvx 'dependency-scout>=0.8.0' triage --repo temporalio/ai-cookbook --local


### PR DESCRIPTION
Updates the Dependency Scout integration for this repo's policy (humans merge to protected branches — no bot auto-merge).

- **Workflow:** pins `dependency-scout>=0.8.0`.
- **Config (`.github/dependency-scout.yml`):** `auto_merge_enabled: true` → `false`.

With 0.8.0, every triaged Dependabot PR gets an at-a-glance verdict label so you can process the queue without opening each comment:

| Verdict | Label | What Scout does |
|---|---|---|
| 🟢 safe | `scout: merge recommended` | leaves it open for you to merge (no ping — GitHub already requests CODEOWNERS) |
| 🟡 needs a look | `scout: needs review` | requests your review |
| 🔴 unsafe | `scout: blocked` | @-mentions CODEOWNERS in the close comment, then closes |

This replaces the previous behavior where safe greens *attempted* an auto-merge this repo (correctly) forbids and showed up as "failed" in the sweep. Now they're vetted, labelled, and handed to a human.

🤖 Generated with [Claude Code](https://claude.com/claude-code)