### PR TITLE
Revise recipe READMEs for the docs style guide

### DIFF
--- a/.github/workflows/docs-build-check.yml
+++ b/.github/workflows/docs-build-check.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "20"
+          node-version: "24"
 
       - name: Detect package manager and install dependencies
         working-directory: documentation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,28 @@ Required fields: `description` (plain text), `tags` (array including category, l
 
 **Tests must pass** before a PR is merged. CI detects changed recipe directories and runs `uv sync && pytest tests/ --timeout=30` for each.
 
+## README Style Guide
+
+Top-level recipe READMEs are published to [docs.temporal.io](https://docs.temporal.io) as MDX pages. The `# H1` becomes the page `title`, the front matter `description` becomes the meta `description`, and the body becomes the page body. Follow the [Temporal documentation style guide](https://github.com/temporalio/documentation/blob/main/STYLE.md) so new recipes match published docs.
+
+**Front matter**
+
+- `description`: one sentence that reads as an SEO meta description. Front-load keywords and name the stack (for example "Build a durable agentic loop in Python with Temporal and the OpenAI Responses API."). End with a period. Write `tags:` with a space after the colon.
+- `tags`: order as `[<category>, python, <provider>]` (for example `[agents, python, openai]`). Reuse existing tags; don't invent one-off tags.
+
+**Titles and headings**
+
+- Use sentence case: capitalize only the first word and proper nouns ("Basic agentic loop with tool calling", not "Basic Agentic Loop With Tool Calling").
+- Keep provider/product names capitalized (Temporal, OpenAI, Claude, MCP, LiteLLM, AI, HTTP).
+- Keep parallel titles across sibling recipes (for example the OpenAI and Claude agentic-loop recipes name their provider the same way).
+
+**Body prose**
+
+- Capitalize Temporal core terms as proper nouns in prose: Workflow, Activity, Worker, Signal, Event History. In code and code comments, follow the language's conventions (lowercase `workflow`, `activity`, etc.).
+- Use "Temporal Service" (not "Cluster") for a running backend, and spell out "identifier" outside core terms (use "Workflow Id", "request identifier").
+- Cut filler ("in order to", "simply", "easily", "just") and vague intensifiers ("powerful", "robust", "seamless", "leverage" → "use"). Prefer brevity.
+- Do not add emojis; use em dashes sparingly.
+
 ## Local Development Prerequisites
 
 - Python 3.10+

--- a/agents/agentic_loop_tool_call_claude_python/README.md
+++ b/agents/agentic_loop_tool_call_claude_python/README.md
@@ -1,9 +1,9 @@
 <!--
-description: A basic agentic loop using Claude (Anthropic) with tool calling.
+description: Build a durable agentic loop in Python with Claude tool calling and Temporal.
 tags: [agents, python, claude]
 priority: 775
 -->
-# Basic Agentic Loop with Claude and Tool Calling
+# Basic agentic loop with Claude and tool calling
 
 This example implements an agentic loop using Claude (Anthropic) that has a set of tools available. If the agent determines that no tools are needed to satisfy a user request, it will return the response directly. If Claude determines a tool should be used, it will return with the name of the chosen tool and any needed parameters. The agent then invokes the appropriate tool.
 
@@ -20,7 +20,7 @@ This recipe highlights the following key design decisions:
 
 Also see this foundational [recipe for basic tool calling](https://docs.temporal.io/ai-cookbook/tool-calling-python).
 
-## Application Components
+## Application components
 
 This example includes the following components:
 - The [Workflow](#create-the-agent-agentic-loop) that contains the agentic loop and tool calling logic; this is the core of the agent implementation.
@@ -30,7 +30,7 @@ This example includes the following components:
 - The [Worker](#create-the-worker) that manages the Workflow and the Activities.
 - An application that [initiates an interaction](#initiate-an-interaction-with-the-agent) with the agent.
 
-## Create the Agent (Agentic Loop)
+## Create the agent (agentic loop)
 
 ### Create the main agentic loop
 
@@ -160,7 +160,7 @@ We create a wrapper for the `create` method of the `AsyncAnthropic` client objec
 
 We set `max_retries=0` when creating the `AsyncAnthropic` client. This moves the responsibility for retries from the Anthropic client to Temporal. This means that the Activity should interpret any errors coming from Claude's API call and return the appropriate error type so that the Workflow knows if it should retry the Activity or not.
 
-In this implementation, we allow for the model, system instructions, messages, lis6t of tools, and max_tokens (required) to be passed in.
+In this implementation, we allow for the model, system instructions, messages, list of tools, and max_tokens (required) to be passed in.
 
 *File: activities/claude_responses.py*
 ```python
@@ -308,7 +308,7 @@ If no tools are needed, respond in haikus.
 
 ## Create tool definitions
 
-Tools are defined in the `tools` directory and should be thought of as independent from the agent implementation; as described above, dynamic Activities are leveraged for this loose coupling.
+Tools are defined in the `tools` directory and should be thought of as independent from the agent implementation; as described above, dynamic Activities are used for this loose coupling.
 
 The `__init__.py` file holds tools for providing location (`get_location_info`), IP address (`get_ip_address`), and weather alerts (`get_weather_alerts`).
 - The `get_tools` method returns the set of tool definitions that will be passed to Claude.
@@ -392,7 +392,7 @@ async def get_location_info(req: GetLocationRequest) -> str:
 
 ## Create the Worker
 
-The worker is the process that dispatches work to the various parts of the agent implementation - the orchestrator and the Activities for Claude and tool invocations.
+The Worker is the process that dispatches work to the various parts of the agent implementation - the orchestrator and the Activities for Claude and tool invocations.
 
 *File: worker.py*
 
@@ -436,7 +436,7 @@ if __name__ == "__main__":
 
 ## Initiate an interaction with the agent
 
-In order to interact with this simple AI agent, we create a Temporal client and execute a Workflow.
+To interact with this simple AI agent, we create a Temporal client and execute a Workflow.
 
 *File: start_workflow.py*
 ```python

--- a/agents/agentic_loop_tool_call_openai_python/README.md
+++ b/agents/agentic_loop_tool_call_openai_python/README.md
@@ -1,9 +1,9 @@
 <!--
-description: A basic agentic loop that invokes a dynamic set of tools. 
-tags: [agents, python]
+description: Build a durable agentic loop in Python that calls a dynamic set of tools with Temporal and the OpenAI Responses API.
+tags: [agents, python, openai]
 priority: 775
 -->
-# Basic Agentic Loop with Tool Calling
+# Basic agentic loop with OpenAI and tool calling
 
 This example implements a basic agentic loop that has a set of tools available. If the
 agent determines that no tools are needed to satisfy a user request, it will respond
@@ -14,14 +14,14 @@ appropriate tool.
 Tools are supplied to the [`responses` API](https://platform.openai.com/docs/api-reference/responses/create) through the [`tools` parameter](https://platform.openai.com/docs/api-reference/responses/create#responses-create-tools). The `tools` parameter is in `json` format and includes a description of the function as well as descriptions of each of the arguments.
 
 > [!WARNING]
-> The API used to generate the tools `json` is an internal function from the [Open AI API](https://github.com/openai/openai-python) and may therefore change in the future. There currently is no public API to generate the tool definition from a Pydantic model or a function signature.
+> The API used to generate the tools `json` is an internal function from the [OpenAI API](https://github.com/openai/openai-python) and may therefore change in the future. There currently is no public API to generate the tool definition from a Pydantic model or a function signature.
 
 Being external API calls, invoking the LLM and invoking any functions/tools are done within a Temporal Activity.
 
 This recipe highlights the following key design decisions:
 - We use dynamic Activities to allow the agent to be loosely coupled from specific
 tools. This sample isolates the tools in the `tools` directory; changing the tools
-requires NO changes to the agent implementation.
+requires no changes to the agent implementation.
 - Because there is an agentic loop, each LLM invocation is passed the accumulated 
 *conversation history*, that includes the initial user input as well as LLM and tool 
 calls.
@@ -31,10 +31,10 @@ calls.
 
 Also see this foundational [recipe for basic tool calling](https://docs.temporal.io/ai-cookbook/tool-calling-python).
 
-## Application Components
+## Application components
 
 This example includes the following components:
-- The [workflow](#create-the-agent-agentic-loop) that contains the agentic loop and tool calling logic; this is the core of the agent implementation.
+- The [Workflow](#create-the-agent-agentic-loop) that contains the agentic loop and tool calling logic; this is the core of the agent implementation.
 - The activities for [invoking the LLM](#create-the-activity-for-llm-invocations) and for [invoking tools](#create-the-activity-for-the-tool-invocation).
 - A [helper function](#create-the-helper-function) that creates tool definitions of the appropriate form.
 - Sample [tools](#create-tool-definitions).
@@ -42,11 +42,11 @@ This example includes the following components:
 - An application that [initiates an interaction](#initiate-an-interaction-with-the-agent) with the agent.
 
 
-## Create the Agent (Agentic Loop)
+## Create the agent (agentic loop)
 
 ### Create the main agentic loop
 
-The agent is implemented as a Temporal workflow that:
+The agent is implemented as a Temporal Workflow that:
 - implements an agentic loop. The loop will continue until the agent responds with
 no tool calls.
 
@@ -295,7 +295,7 @@ If no tools are needed, respond in haikus.
 ## Create tool definitions
 
 Tools are defined in the `tools` directory and should be thought of as independent 
-from the agent implementation; as described above, dynamic Activities are leveraged 
+from the agent implementation; as described above, dynamic Activities are used 
 for this loose coupling. 
 
 The `__init__.py` file holds two examples of tool sets,
@@ -390,11 +390,11 @@ def get_location_info(req: GetLocationRequest) -> str:
     return f"{result['city']}, {result['regionName']}, {result['country']}"
 ```
 
-See files in github for more tool definitions.
+See files in GitHub for more tool definitions.
 
 ## Create the Worker
 
-The worker is the process that dispatches work to the various parts of the agent implementation - the orchestrator and the activities for the LLM and tool invocations.
+The Worker is the process that dispatches work to the various parts of the agent implementation - the orchestrator and the Activities for the LLM and tool invocations.
 
 *File: worker.py*
 
@@ -438,7 +438,7 @@ if __name__ == "__main__":
 
 ## Initiate an interaction with the agent
 
-In order to interact with this simple AI agent, we create a Temporal client and execute a workflow.
+To interact with this simple AI agent, we create a Temporal client and execute a Workflow.
 
 *File:start_workflow.py*
 ```python

--- a/agents/human_in_the_loop_python/README.md
+++ b/agents/human_in_the_loop_python/README.md
@@ -1,15 +1,15 @@
 <!--
-description: Support human in the loop (HITL) in agentic flows.
-tags: [agents, python]
+description: Add human-in-the-loop approval to a durable AI agent using Temporal Signals in Python.
+tags: [agents, python, openai]
 priority: 750
 -->
-# Human-in-the-Loop AI Agent
+# Human-in-the-loop AI agent
 
 This example demonstrates how to build an AI agent that requires human approval; we use Temporal Signals to bring that user input into the agent.
 
 ## Overview
 
-The workflow implements the agent flow:
+The Workflow implements the agent flow:
 1. Uses an LLM to analyze a user request and propose an action. 
 2. If the proposed action is deemed risky, pauses and waits for human approval via Temporal Signal
 3. Executes the action if auto-approved (if not risky) or human approved, or cancels if rejected/timed out
@@ -17,7 +17,7 @@ The workflow implements the agent flow:
 Key features:
 - **Resource efficient waiting**: Can wait for approval for hours, days or indefinitely; while waiting, the agent consumes no compute resources.
 - **Signal-based approval**: External systems send approval decisions via Temporal Signals
-- **Durable timers**: Time limits placed on human int he loop steps survive any execution distruptions.
+- **Durable timers**: Time limits placed on human-in-the-loop steps survive any execution disruptions.
 - **Complete audit trail**: All decisions are logged for compliance
 
 ## Prerequisites
@@ -59,11 +59,11 @@ In another terminal:
 uv run python -m start_workflow "Delete all test data from the production database"
 ```
 
-The workflow will start, analyze the request, and pause for approval. Watch the worker output for instructions.
+The Workflow will start, analyze the request, and pause for approval. Watch the Worker output for instructions.
 
-### Send Approval Decision
+### Send approval decision
 
-The worker output will show the workflow ID and request ID. In another terminal, run the `send_approval` script to approve or reject:
+The Worker output will show the Workflow Id and request identifier. In another terminal, run the `send_approval` script to approve or reject:
 
 **To approve:**
 ```bash
@@ -75,9 +75,9 @@ uv run python -m send_approval <workflow-id> <request-id> approve "Looks good"
 uv run python -m send_approval <workflow-id> <request-id> reject "Too risky"
 ```
 
-### Testing Timeout
+### Testing timeout
 
-To test timeout behavior, simply don't send any approval signal. After 5 minutes (default), the workflow will automatically complete with a timeout result.
+To test timeout behavior, don't send any approval signal. After 5 minutes (default), the Workflow will automatically complete with a timeout result.
 
 ## Architecture
 
@@ -85,8 +85,8 @@ To test timeout behavior, simply don't send any approval signal. After 5 minutes
 - **Activities**:
   - `openai_responses.py`: Generic LLM invocation activity
   - `execute_action.py`: Executes approved actions
-    - The "execution" of approved actions in this sample simply logs messages.
-    - In a realistic scenario, a set of tools will have been provided to the LLM and the result might be a recommended tool call. In this case, if approved, the agent would invoke the tool via an activity. See the [agentic loop with tool calling](https://docs.temporal.io/ai-cookbook/agentic-loop-tool-call-openai-python) for guidance on how to use dynamic activities, allowing the tools to be loosely coupled from the agent implementation.
+    - The "execution" of approved actions in this sample logs messages.
+    - In a realistic scenario, a set of tools will have been provided to the LLM and the result might be a recommended tool call. In this case, if approved, the agent would invoke the tool via an Activity. See the [agentic loop with tool calling](https://docs.temporal.io/ai-cookbook/agentic-loop-tool-call-openai-python) for guidance on how to use dynamic Activities, allowing the tools to be loosely coupled from the agent implementation.
   - `notify_approval_needed.py`: Notifies external systems of approval requests
     - In this sample the notification comes in the form of messages printed in the terminal running the worker.
     - In a realistic scenario, the notification activity may send emails, deliver messages to slack, etc.
@@ -96,16 +96,16 @@ To test timeout behavior, simply don't send any approval signal. After 5 minutes
   - `start_workflow.py`: Starts workflow execution
   - `send_approval.py`: Helper script to send approval signals
 
-## Key Patterns
+## Key patterns
 
-We use a Temporal signal to inject information from the human into the waiting workflow. The signal is delivered from some UI (in this case the `send_approval.py` script) that uses a Temporal client to deliver the data.
+We use a Temporal Signal to inject information from the human into the waiting Workflow. The Signal is delivered from some UI (in this case the `send_approval.py` script) that uses a Temporal client to deliver the data.
 
 <img src="_assets/temporal_signal_handling.png">
 
 Within the agent implementation there are three main elements to the solution.
 
-### Local state within the workflow implementation
-This state will be written to via the signal handler and will be part of the condition that defines the wait point.
+### Local state within the Workflow implementation
+This state will be written to via the Signal handler and will be part of the condition that defines the wait point.
 ```python
 @workflow.defn
 class HumanInTheLoopWorkflow:
@@ -113,8 +113,8 @@ class HumanInTheLoopWorkflow:
         self.current_decision: Optional[ApprovalDecision] = None
         self.pending_request_id: Optional[str] = None
 ```
-### Signal Handler
-The workflow uses a signal handler to receive approval decisions asynchronously:
+### Signal handler
+The Workflow uses a Signal handler to receive approval decisions asynchronously:
 ```python
 @workflow.signal
 async def approval_decision(self, decision: ApprovalDecision):
@@ -123,8 +123,8 @@ async def approval_decision(self, decision: ApprovalDecision):
     ...
 ```
 
-### Waiting with Timeout
-The workflow waits for approval with a configurable timeout:
+### Waiting with timeout
+The Workflow waits for approval with a configurable timeout:
 ```python
 await workflow.wait_condition(
     lambda: self.approval_decision is not None,

--- a/agents/openai_agents_sdk_python/README.md
+++ b/agents/openai_agents_sdk_python/README.md
@@ -1,26 +1,26 @@
 <!--
-description: Build a durable AI agent with OpenAI Agents SDK and Temporal that can intelligently choose tools to answer user questions
+description: Build a durable AI agent with the OpenAI Agents SDK and Temporal that chooses tools to answer user questions.
 tags: [agents, python, openai]
 priority: 750
 -->
 
-# Durable Agent with Tools - OpenAI Agents SDK
+# Durable agent with tools using the OpenAI Agents SDK
 
-In this example, we show you how to build a Durable Agent using the [OpenAI Agents SDK Integration for Temporal](https://github.com/temporalio/sdk-python/tree/main/temporalio/contrib/openai_agents). The AI agent we build will have access to [tools](https://github.com/temporalio/sdk-python/tree/main/temporalio/contrib/openai_agents#tool-calling) (Temporal Activities) to answer user questions. The agent can determine which tools to use based on the user's input and execute them as needed.
+In this example, we show you how to build a durable agent using the [OpenAI Agents SDK Integration for Temporal](https://github.com/temporalio/sdk-python/tree/main/temporalio/contrib/openai_agents). The AI agent we build will have access to [tools](https://github.com/temporalio/sdk-python/tree/main/temporalio/contrib/openai_agents#tool-calling) (Temporal Activities) to answer user questions. The agent can determine which tools to use based on the user's input and execute them as needed.
 
 This recipe highlights key implementation patterns:
 
-- **Agent-based architecture**: Uses the OpenAI Agents SDK to create an intelligent agent that can reason about which tools to use and handles LLM invocation for you.
-- **Tool integration**: Temporal Activities can be seamlessly used as tools by the agent. The integration offers the **activity_as_tool** helper function, which:
-  - Automatically generates OpenAI-compatible tool schemas from activity function signatures
-  - Wraps activities as agent tools that can be provided directly to the Agent
-  - Enables the agent to invoke Temporal Activities as tools leveraging Temporal's durable execution for tool calls
+- **Agent-based architecture**: Uses the OpenAI Agents SDK to create an agent that can reason about which tools to use and handles LLM invocation for you.
+- **Tool integration**: Temporal Activities can be used as tools by the agent. The integration offers the **activity_as_tool** helper function, which:
+  - Automatically generates OpenAI-compatible tool schemas from Activity function signatures
+  - Wraps Activities as agent tools that can be provided directly to the Agent
+  - Enables the agent to invoke Temporal Activities as tools, using Temporal's durable execution for tool calls
 - **Durable execution**: The agent's state and execution are managed by Temporal, providing reliability and observability
 - **Plugin configuration**: Uses the `OpenAIAgentsPlugin` to configure Temporal for OpenAI Agents SDK integration
 
 ## Create the Activity
 
-We create activities that serve as tools for the agent. These activities can perform various tasks like getting weather information or performing calculations.
+We create Activities that serve as tools for the agent. These Activities can perform tasks like getting weather information or performing calculations.
 
 *File: activities/tools.py*
 
@@ -49,7 +49,7 @@ async def calculate_circle_area(radius: float) -> float:
 
 ## Create the Workflow
 
-The workflow creates an agent with specific instructions and tools. The agent can then process user input and decide which tools to use to answer questions. Since LLM invocation is an external API call, this typically would happen in a Temporal Activity. However, because of the Temporal Integration with OpenAI Agents SDK, this is being handled for us and we do not need to implement the Activity ourselves.
+The Workflow creates an agent with specific instructions and tools. The agent can then process user input and decide which tools to use to answer questions. Since LLM invocation is an external API call, this typically would happen in a Temporal Activity. However, because of the Temporal integration with the OpenAI Agents SDK, this is handled for us and we do not need to implement the Activity ourselves.
 
 *File: workflows/hello_world_workflow.py*
 
@@ -131,7 +131,7 @@ if __name__ == "__main__":
 
 ## Create the Workflow Starter
 
-The starter script submits the agent workflow to Temporal for execution, then waits for the result and prints it out.
+The starter script submits the agent Workflow to Temporal for execution, then waits for the result and prints it out.
 It uses the `OpenAIAgentsPlugin` to match the Worker configuration.
 
 *File: start_workflow.py*
@@ -201,7 +201,7 @@ Start execution:
 uv run python -m start_workflow
 ```
 
-## Example Interactions
+## Example interactions
 
 Try asking the agent questions like:
 
@@ -209,4 +209,4 @@ Try asking the agent questions like:
 - "Calculate the area of a circle with radius 5"
 - "What's the weather in Tokyo and calculate the area of a circle with radius 3"
 
-The agent will determine which tools to use and provide intelligent responses based on the available tools. Use the [OpenAI Traces dashboard](https://platform.openai.com/traces) to visualize and monitor your workflows and tool calling.
+The agent will determine which tools to use and provide responses based on the available tools. Use the [OpenAI Traces dashboard](https://platform.openai.com/traces) to visualize and monitor your Workflows and tool calling.

--- a/agents/tool_call_openai_python/README.md
+++ b/agents/tool_call_openai_python/README.md
@@ -1,17 +1,17 @@
 <!--
-description: Build a simple, non-looping agent that gives agency to the LLM to choose tools, and then invokes chosen tools. 
-tags: [agents, python]
+description: Build a simple, non-looping Python agent that lets the LLM choose tools and then invokes the chosen tools with Temporal and OpenAI.
+tags: [agents, python, openai]
 priority: 775
 -->
 
 # Tool calling agent
 
-In this example, we demonstrate how function calling (also known as tool calling) works with the [Open AI API](https://github.com/openai/openai-python) and Temporal. Tool calling allows the model to make decisions on which, if any, functions should be invoked. It also provides information to the LLM that will allow it to structure the response in such a way that the agent can easily invoke the functions.
+In this example, we demonstrate how function calling (also known as tool calling) works with the [OpenAI API](https://github.com/openai/openai-python) and Temporal. Tool calling allows the model to make decisions on which, if any, functions should be invoked. It also provides information to the LLM that will allow it to structure the response so that the agent can invoke the functions.
 
-Tools are supplied to the [`responses` API](https://platform.openai.com/docs/api-reference/responses/create) through the [`tools` parameter](https://platform.openai.com/docs/api-reference/responses/create#responses-create-tools). The `tools` parameter is in`json` and includes a description of the function as well as descriptions of each of the arguments.
+Tools are supplied to the [`responses` API](https://platform.openai.com/docs/api-reference/responses/create) through the [`tools` parameter](https://platform.openai.com/docs/api-reference/responses/create#responses-create-tools). The `tools` parameter is in `json` and includes a description of the function as well as descriptions of each of the arguments.
 
 > [!WARNING]
-> The API used to generate the tools json is an internal function from the [Open AI API](https://github.com/openai/openai-python) and may therefore change in the future. There currently is no public API to generate the tool definition from a Pydantic model or a function signature.
+> The API used to generate the tools json is an internal function from the [OpenAI API](https://github.com/openai/openai-python) and may therefore change in the future. There currently is no public API to generate the tool definition from a Pydantic model or a function signature.
 
 Being external API calls, invoking the LLM and invoking the function are each done within a Temporal Activity.
 
@@ -71,10 +71,10 @@ async def create(request: OpenAIResponsesRequest) -> Response:
 
 We create a wrapper for invoking the [National Weather Service API](https://www.weather.gov/documentation/services-web-api), specifically for the weather alerts endpoint.
 
-We follow the Temporal best practice of encapsulating all input parameters to the activity in
-data structure, even here where this is only one argument.
+We follow the Temporal best practice of encapsulating all input parameters to the Activity in
+a data structure, even here where this is only one argument.
 
-The `WEATHER_ALERTS_TOOL_OAI` leverages a function defined in `helpers/tool_helpers.py` that calls the aforementioned internal OpenAI function, generating a dictionary that becomes the argument passed into the OpenAI responses API.
+The `WEATHER_ALERTS_TOOL_OAI` uses a function defined in `helpers/tool_helpers.py` that calls the aforementioned internal OpenAI function, generating a dictionary that becomes the argument passed into the OpenAI responses API.
 
 `activities/get_weather_alerts.py`
 ```python
@@ -136,7 +136,7 @@ async def get_weather_alerts(weather_alerts_request: GetWeatherAlertsRequest) ->
 The `oai_responses_tool_from_model` function accepts a tool name and description, as well as a list of argument name/description pairs and returns json that is in the format expected for tool definitions in the OpenAI responses API.
 
 > [!WARNING]
-> The API used to generate the tools json is an interal function from the [Open AI API](https://github.com/openai/openai-python) and may therefore change in the future. There currently is no public API to generate the tool definition from a Pydantic model or a function signature.
+> The API used to generate the tools json is an internal function from the [OpenAI API](https://github.com/openai/openai-python) and may therefore change in the future. There currently is no public API to generate the tool definition from a Pydantic model or a function signature.
 
 `helpers/tool_helpers.py`
 ```python
@@ -155,10 +155,10 @@ def oai_responses_tool_from_model(name: str, description: str, model: type[BaseM
     }
 ```
 
-## Create the Agent
+## Create the agent
 
-The agent is implemented as a Temporal workflow that orchestrates 
-- the intial LLM call with the initial user input and guidance to the LLM that they should respond in haiku when the user input doesn't lead to a tool call,
+The agent is implemented as a Temporal Workflow that orchestrates 
+- the initial LLM call with the initial user input and guidance to the LLM that they should respond in haiku when the user input doesn't lead to a tool call,
 - the invocation of the function, if the LLM has chosen one
 - and if a function has been called, the result is appended to the context that is then sent back to the LLM for interpretation (the LLM is instructed to format the tool response).
 
@@ -233,11 +233,11 @@ class ToolCallingWorkflow:
         result = result.output_text
 
         return result
- ```
+```
 
 ## Create the Worker
 
-The worker is the process that dispatches work to the various parts of the agent implementation - the orchestrator and the activities for the LLM and tool invocations.
+The Worker is the process that dispatches work to the various parts of the agent implementation - the orchestrator and the Activities for the LLM and tool invocations.
 
 *File: worker.py*
 
@@ -278,7 +278,7 @@ if __name__ == "__main__":
 
 ## Initiate an interaction with the agent
 
-In order to interact with this simple AI agent, we create a Temporal client and execute a workflow.
+To interact with this simple AI agent, we create a Temporal client and execute a Workflow.
 
 `start_workflow.py`
 ```python

--- a/deep_research/basic_openai_python/README.md
+++ b/deep_research/basic_openai_python/README.md
@@ -1,11 +1,10 @@
 <!-- 
-description: Build a simple deep research system embodying the standard
-deep research architecture.
-tags: [agents, toolcalling, python]
+description: Build a multi-agent deep research system in Python with Temporal and the OpenAI Responses API.
+tags: [agents, python, openai]
 priority: 399
 -->
 
-# Deep Research
+# Deep research
 
 Deep research systems combine multiple agents with information retrieval from
 the web or other sources to produce evidence-based reports on specific topics.
@@ -105,10 +104,10 @@ class ResearchReport(BaseModel):
     follow_up_questions: List[str]
 ```
 
-## Create the Agents
+## Create the agents
 
 The deep research system uses four specialized agents, each implemented as
-Temporal activities. In this implementation, each agent is implemented as a
+Temporal Activities. In this implementation, each agent is implemented as a
 single call to the OpenAI Responses API.
 
 This is possible because we are using structured outputs, which guarantee the
@@ -117,10 +116,10 @@ response will be in the correct format, eliminating the need for retries.
 The web search agent also requires only a single API call because OpenAI
 integrates the web search tool into the Responses API.
 
-These agents run in the Workflow and use the `invoke_model` activity to make
+These agents run in the Workflow and use the `invoke_model` Activity to make
 OpenAI API calls. It is critical to set the `start_to_close_timeout` for these
-activities to a value that is long enough to complete the task. If it is too
-short, the activity will fail with a timeout error, causing a retry loop that
+Activities to a value that is long enough to complete the task. If it is too
+short, the Activity will fail with a timeout error, causing a retry loop that
 never completes. Response times for reasoning models such as `GPT-5` can vary
 significantly depending on the nature of the request. Web search times also vary
 depending on the size and content of the documents located by the search.

--- a/foundations/claim_check_pattern_python/README.md
+++ b/foundations/claim_check_pattern_python/README.md
@@ -1,10 +1,10 @@
 <!-- 
-description: Use the Claim Check pattern to handle large payloads to workflows and activities.
-tags:[foundations, claim-check, python, s3]
+description: Use the Claim Check pattern with Temporal to keep large payloads out of Event History by offloading them to S3.
+tags: [foundations, python, s3, claim-check]
 priority: 400
 -->
 
-# Claim Check Pattern with Temporal
+# Claim check pattern with Temporal
 
 This recipe demonstrates how to use the Claim Check pattern to offload data from Temporal Server's Event History to external storage. This can be useful in conversational AI applications that include the full conversation history with each LLM call, creating large Event History that can exceed server size limits.
 
@@ -15,9 +15,9 @@ This recipe includes:
 - A lightweight codec server for a better Web UI experience
 - An AI/RAG example workflow that demonstrates the pattern end-to-end
 
-## How the Claim Check Pattern Works
+## How the Claim Check pattern works
 
-Each Temporal Workflow has an associated Event History that is stored in Temporal Server and used to provide durable execution. When using the Claim Check pattern, we store the payload content of the Event in separate storage system, then store a reference to that storage in the Temporal Event History instead.
+Each Temporal Workflow has an associated Event History that is stored in Temporal Server and used to provide durable execution. When using the Claim Check pattern, we store the payload content of the Event in a separate storage system, then store a reference to that storage in the Temporal Event History instead.
 
 The Claim Check Recipe implements a `PayloadCodec` that:
 
@@ -26,7 +26,7 @@ The Claim Check Recipe implements a `PayloadCodec` that:
 
 Workflows operate with small, lightweight keys while maintaining transparent access to full data through automatic encoding/decoding.
 
-## Claim Check Codec Implementation
+## Claim Check codec implementation
 
 The `ClaimCheckCodec` implements `PayloadCodec` and adds an inline threshold to keep small payloads inline. This avoids the latency costs of uploading/downloading the payload externally when it's not required.
 
@@ -222,7 +222,7 @@ class ClaimCheckCodec(PayloadCodec):
 - Where configured: `ClaimCheckCodec(max_inline_bytes=20 * 1024)` in `codec/claim_check.py`
 - Change by passing a different `max_inline_bytes` when constructing `ClaimCheckCodec`
 
-## Claim Check Plugin
+## Claim Check plugin
 
 The `ClaimCheckPlugin` integrates the codec with the Temporal client configuration.
 
@@ -253,11 +253,11 @@ class ClaimCheckPlugin(SimplePlugin):
         )
 ```
 
-## Example: AI / RAG Workflow using Claim Check
+## Example: AI/RAG Workflow using Claim Check
 
 This example ingests a large text, performs lightweight lexical retrieval, and answers a question with an LLM. Large intermediates (chunks, scores) are kept out of Temporal payloads via the Claim Check codec. Only the small final answer is returned inline.
 
-### Shared Models
+### Shared models
 
 *File: shared/models.py*
 
@@ -486,7 +486,7 @@ uv run python -m start_workflow
 
 To demonstrate payload size failures without claim check, you can disable it in your local wiring (e.g., omit the plugin/codec) and re-run. With claim check disabled, large payloads may exceed Temporal's default payload size limits and fail.
 
-## Codec Server for Web UI
+## Codec server for Web UI
 
 When claim check is enabled, the Web UI would otherwise show opaque keys. This codec server shows helpful text with a link to view the raw data on demand.
 
@@ -627,7 +627,7 @@ if __name__ == "__main__":
     web.run_app(build_codec_server(), host="127.0.0.1", port=8081)
 ```
 
-### Running the Codec Server
+### Running the codec server
 
 ```bash
 uv run python -m codec.codec_server

--- a/foundations/hello_world_litellm_python/README.md
+++ b/foundations/hello_world_litellm_python/README.md
@@ -1,20 +1,20 @@
 <!-- 
-description: Integrate LiteLLM into a Temporal Workflow in Python.
-tags:[python, litellm, provider-neutral]
+description: Integrate LiteLLM into a durable Temporal Workflow in Python to call and switch between LLM providers.
+tags: [foundations, python, litellm]
 priority: 920
 -->
 
-# Hello World with LiteLLM
+# Hello world with LiteLLM
 
 [LiteLLM](https://github.com/BerriAI/litellm) is a library for calling LLMs from Python. It makes it easy to access, and switch between, many providers, including OpenAI, Anthropic, Google, and more.
 
-This recipe mirrors the [Basic Python recipe](../hello_world_openai_responses_python/README.md), but swaps the OpenAI SDK for LiteLLM. The workflow still delegates LLM calls to an Activity, letting Temporal coordinate retries and durability, while LiteLLM forwards those calls to your configured provider.
+This recipe mirrors the [Basic Python recipe](../hello_world_openai_responses_python/README.md), but swaps the OpenAI SDK for LiteLLM. The Workflow still delegates LLM calls to an Activity, letting Temporal coordinate retries and durability, while LiteLLM forwards those calls to your configured provider.
 
 Key points:
 
 - A reusable Activity that wraps `litellm.acompletion` and keeps retries in Temporal.
 - The most common LiteLLM parameters are on `LiteLLMRequest` ensuring type checking and IDE completion. Others may be passed via the `extra_options` dictionary, which functions as `kwargs` for `litellm.acompletion`.
-- The Activity returns the full LiteLLM response for processing by the workflow.
+- The Activity returns the full LiteLLM response for processing by the Workflow.
 
 ## Create the Activity
 

--- a/foundations/hello_world_openai_responses_python/README.md
+++ b/foundations/hello_world_openai_responses_python/README.md
@@ -1,16 +1,16 @@
 <!-- 
-description: Simple example demonstrating how to call an LLM from Temporal using the OpenAI Python API library.
-tags:[foundations, openai, python]
+description: Call an LLM from a durable Temporal Workflow in Python using the OpenAI API library.
+tags: [foundations, python, openai]
 priority: 999
 -->
 
-# Hello World
+# Hello world
 
 This is a simple example showing how to call an LLM from Temporal using the [OpenAI Python API library](https://github.com/openai/openai-python).
 
 Being an external API call, the LLM invocation happens in a Temporal Activity.
 
-This recipe highlights two key design decisions:
+This recipe highlights three key design decisions:
 
 - A generic Activity for invoking an LLM API. This Activity can be re-used with different arguments throughout your codebase.
 - Configuring the Temporal client with a `dataconverter` to allow serialization of Pydantic types.
@@ -135,7 +135,7 @@ if __name__ == "__main__":
 
 ## Create the Workflow Starter
 
-The starter script submits the workflow to Temporal for execution, then waits for the result and prints it out.
+The starter script submits the Workflow to Temporal for execution, then waits for the result and prints it out.
 It uses the `pydantic_data_converter` to match the Worker configuration.
 
 *File: start_workflow.py*

--- a/foundations/http_retry_enhancement_python/README.md
+++ b/foundations/http_retry_enhancement_python/README.md
@@ -1,10 +1,10 @@
 <!-- 
-description: Extract retry information from HTTP response headers and make it available to Temporal's retry mechanisms.
-tags:[foundations, openai, python]
+description: Extract retry information from HTTP response headers and pass it to Temporal's retry mechanisms in Python.
+tags: [foundations, python, openai]
 priority: 920
 -->
 
-# Retry Policy from HTTP Responses
+# Retry policy from HTTP responses
 
 This recipe extends the [Basic Example](../hello_world_openai_responses_python/README.md) to show how to extract retry information from HTTP response headers and make it available to Temporal's retry mechanisms.
 

--- a/foundations/structured_output_openai_responses_python/README.md
+++ b/foundations/structured_output_openai_responses_python/README.md
@@ -1,10 +1,10 @@
 <!-- 
-description: Use Temporal and OpenAI Responses API to reliably request output conforming to a specific data structure. 
-tags:[foundations, openai, python]
+description: Use Temporal and the OpenAI Responses API to reliably request output conforming to a specific data structure.
+tags: [foundations, python, openai]
 priority: 980
 -->
 
-# Structured Outputs with Temporal and OpenAI
+# Structured outputs with Temporal and OpenAI
 
 The OpenAI Responses API provides the [Structured Outputs API](https://platform.openai.com/docs/guides/structured-outputs) allowing you to request responses conforming to a specific data structure.
 
@@ -14,7 +14,7 @@ Structured outputs are also commonly used for tool calling.
 OpenAI usually returns the correct type. However, this is not always the case due to the non-deterministic nature of LLMs.
 When OpenAI returns an incorrect type, Temporal automatically retries the LLM call Activity.
 
-## Invoke Model Activity
+## Invoke model Activity
 
 We create a model-calling Activity that uses the `responses.parse` method of the OpenAI client.
 

--- a/mcp/hello_world_durable_mcp_server/README.md
+++ b/mcp/hello_world_durable_mcp_server/README.md
@@ -1,9 +1,9 @@
 <!--
-description: A durable MCP server that uses Temporal workflows for reliable execution of weather tools.
+description: Build a durable MCP server in Python that runs weather tools reliably with Temporal Workflows.
 tags: [mcp, python, workflows]
 priority: 775
 -->
-# Durable MCP Weather Server
+# Durable MCP weather server
 
 This example demonstrates how to build a durable MCP (Model Context Protocol) server using Temporal Workflows for Durable Execution. The server exposes weather tools that fetch alerts and forecasts from the National Weather Service API.
 
@@ -12,31 +12,31 @@ MCP tools are "actions" that the MCP server can perform. Within a given MCP tool
 - Call the National Weather Service API again to retrieve the forecast for that region
 - Format and return the response to the user
 
-In this one tool alone, we are taking several steps to complete a given action. We implement these steps in a Temporal Workflow, which ensures durability out-of-the-box. This means that whenever your MCP tool is called, it kicks off the Temporal Workflow, and every step (API call, function) is executed reliably and all the way to completion.
+In this one tool alone, we are taking several steps to complete a given action. We implement these steps in a Temporal Workflow, which provides durability. This means that whenever your MCP tool is called, it kicks off the Temporal Workflow, and every step (API call, function) is executed reliably and all the way to completion.
 
 We use [FastMCP](https://github.com/jlowin/fastmcp) to implement the MCP Server and create tools using the decorator `@mcp.tool`.
 
 > [!NOTE]
-> External API calls are made within Temporal Activities. This ensures that network requests are retried appropriately and failures are handled gracefully.
+> External API calls are made within Temporal Activities. This ensures that network requests are retried appropriately and failures are handled.
 
 This recipe highlights the following key design decisions:
-- **Separation of concerns**: MCP tools act as thin wrappers that start Temporal Workflows. All business logic lives in workflows, ensuring durability and reliability.
+- **Separation of concerns**: MCP tools act as thin wrappers that start Temporal Workflows. All business logic lives in Workflows, ensuring durability and reliability.
 - **Durable Execution**: By moving multi-step operations into Temporal Workflows, we guarantee that operations complete even in the face of failures, network issues, or process restarts.
 - **Activity-based external calls**: All external API calls (like NWS API requests) are made within Temporal Activities, which provides automatic retries and proper error handling.
-- **Retry policies**: Workflows use configurable retry policies to handle transient failures gracefully.
+- **Retry policies**: Workflows use configurable retry policies to handle transient failures.
 
 Also see this foundational [recipe for basic tool calling](https://docs.temporal.io/ai-cookbook/tool-calling-python) using the same weather tools.
 
-## Application Components
+## Application components
 
 This example includes the following components:
-- The [MCP server](#create-the-mcp-server) (mcp_server.py) that exposes tools via FastMCP and starts Temporal workflows
+- The [MCP server](#create-the-mcp-server) (mcp_server.py) that exposes tools via FastMCP and starts Temporal Workflows
 - The [Workflows](#create-the-workflows) (weather_workflows.py) that orchestrate the multi-step weather operations
 - The [Activity](#create-the-activity) (weather_activities.py) for making external API calls to the National Weather Service
 - The [Worker](#create-the-worker) (worker.py) (that manages the Workflows and Activities)
 - [Config for Claude Desktop](#configure-claude-desktop) (claude_desktop_config.json) for connecting the MCP server to Claude Desktop
 
-## Create the MCP Server
+## Create the MCP server
 
 The MCP server is implemented using FastMCP and exposes tools via the `@mcp.tool` decorator. Each tool is a thin wrapper that starts a Temporal Workflow and waits for the result. This design ensures that all business logic lives in durable Workflows.
 
@@ -102,7 +102,7 @@ if __name__ == "__main__":
 
 ## Create the Workflows
 
-The Workflows contain the business logic for fetching weather data. They orchestrate multiple steps, including API calls and data formatting. By implementing this logic in workflows, we ensure that operations complete reliably even if there are failures or interruptions.
+The Workflows contain the business logic for fetching weather data. They orchestrate multiple steps, including API calls and data formatting. By implementing this logic in Workflows, we ensure that operations complete reliably even if there are failures or interruptions.
 
 ### GetAlerts Workflow
 
@@ -251,7 +251,7 @@ async def make_nws_request(url: str) -> dict[str, Any] | None:
 
 ## Create the Worker
 
-The Worker is the process that excutes Activities and Workflows. 
+The Worker is the process that executes Activities and Workflows. 
 
 *File: worker.py*
 
@@ -328,7 +328,7 @@ This recipe uses Temporal's environment configuration system to connect to Tempo
 
    For TLS certificate authentication instead of API key, refer to the [Temporal environment configuration documentation](https://docs.temporal.io/develop/environment-configuration) for details.
 
-## Running the MCP Server
+## Running the MCP server
 
 1. Install dependencies:
    ```bash
@@ -357,4 +357,4 @@ You can now ask Claude something like `What is the weather like in San Francisco
 > [!NOTE]
 > The National Weather Service API only supports US locations. Asking about weather in non-US locations (e.g., "What is the weather in London?") will result in a 404 error from the API. 
 
-After tool execution, Claude Desktop will send the result over to the LLM (with other context) for human formating, and then returns that result to the user. You can see these and other MCP-related actions in the `mcp_server.log`.
+After tool execution, Claude Desktop will send the result over to the LLM (with other context) for human formatting, and then returns that result to the user. You can see these and other MCP-related actions in the `mcp_server.log`.


### PR DESCRIPTION
## Summary

- Rewrite recipe README comment-block descriptions for SEO and normalize `tags` formatting/order to `[<category>, python, <provider>]`.
- Convert page titles (H1) and section headings to sentence case, keeping product names capitalized and sibling recipe titles parallel.
- Capitalize Temporal core terms in prose, remove filler and banned intensifiers, and fix typos across recipe bodies.
- Add a "README Style Guide" section to `CLAUDE.md` documenting these conventions for future recipes.

These READMEs are published to docs.temporal.io as MDX (H1 → title, front matter `description` → meta description), so the changes align them with the Temporal documentation style guide.

## Test plan

- [ ] CI passes (README front matter validation + recipe tests).
- [ ] Spot-check rendered titles/descriptions once regenerated in the documentation repo.