### PR TITLE
Use `uv run <script>.py` in docs and fix README rendering nits

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,8 +15,8 @@ All Python recipes use [`uv`](https://docs.astral.sh/uv/) for dependency managem
 ```bash
 uv sync                  # install/sync dependencies
 uv run pytest tests/     # run the full test suite
-uv run python -m worker  # start the Temporal worker (separate terminal)
-uv run python -m start_workflow  # trigger a workflow execution
+uv run worker.py         # start the Temporal worker (separate terminal)
+uv run start_workflow.py # trigger a workflow execution
 ```
 
 To run a single test:

--- a/agents/agentic_loop_tool_call_claude_python/README.md
+++ b/agents/agentic_loop_tool_call_claude_python/README.md
@@ -332,7 +332,7 @@ The `__init__.py` file holds tools for providing location (`get_location_info`),
 - The `get_tools` method returns the set of tool definitions that will be passed to Claude.
 - The `get_handler` method captures the mapping from tool name to tool function.
 
-*File: tools/__init__.py*
+*File: tools/\_\_init\_\_.py*
 ```python
 from typing import Any, Awaitable, Callable
 
@@ -505,20 +505,20 @@ uv sync
 Start the agent Worker:
 
 ```bash
-uv run python -m worker
+uv run worker.py
 ```
 
 Make request to the agent:
 
 ```bash
-uv run python -m start_workflow "are there any weather alerts for where I am?"
+uv run start_workflow.py "are there any weather alerts for where I am?"
 ```
 
 Try a number of different user prompts:
 ```bash
-uv run python -m start_workflow "where am I?"
-uv run python -m start_workflow "what is my ip address?"
-uv run python -m start_workflow "tell me about recursion"
+uv run start_workflow.py "where am I?"
+uv run start_workflow.py "what is my ip address?"
+uv run start_workflow.py "tell me about recursion"
 ```
 
 ## Troubleshooting

--- a/agents/agentic_loop_tool_call_openai_python/README.md
+++ b/agents/agentic_loop_tool_call_openai_python/README.md
@@ -256,7 +256,7 @@ async def dynamic_tool_activity(args: Sequence[RawValue]) -> dict:
 The `oai_responses_tool_from_model` function accepts a tool name and description, as well as a list of argument name/description pairs and returns json that is in the format expected for tool definitions in the OpenAI responses API.
 
 > [!WARNING]
-> The API used to generate the tools json is an internal function from the [Open AI API](https://github.com/openai/openai-python) and may therefore change in the future. There currently is no public API to generate the tool definition from a Pydantic model or a function signature.
+> The API used to generate the tools json is an internal function from the [OpenAI API](https://github.com/openai/openai-python) and may therefore change in the future. There currently is no public API to generate the tool definition from a Pydantic model or a function signature.
 
 *File: helpers/tool_helpers.py*
 ```python
@@ -306,7 +306,7 @@ updating the `get_tools` and `get_handler` methods).
 the LLM.
 - The `get_handler` method captures the mapping from tool name to tool function
 
-*File: tools/__init__.py*
+*File: tools/\_\_init\_\_.py*
 ```python
 # Uncomment and comment out the tools you want to use
 
@@ -440,7 +440,7 @@ if __name__ == "__main__":
 
 To interact with this simple AI agent, we create a Temporal client and execute a Workflow.
 
-*File:start_workflow.py*
+*File: start_workflow.py*
 ```python
 import asyncio
 import sys
@@ -490,18 +490,18 @@ uv sync
 Start the agent worker:
 
 ```bash
-uv run python -m worker
+uv run worker.py
 ```
 
 Make request to the agent:
 
 ```bash
-uv run python -m start_workflow "are there any weather alerts for where I am?"
+uv run start_workflow.py "are there any weather alerts for where I am?"
 ```
 
 Try a number of different user prompts:
 ```bash
-uv run python -m start_workflow "where am I?"
-uv run python -m start_workflow "what is my ip address?"
-uv run python -m start_workflow "can I please have a random number?"
+uv run start_workflow.py "where am I?"
+uv run start_workflow.py "what is my ip address?"
+uv run start_workflow.py "can I please have a random number?"
 ```

--- a/agents/human_in_the_loop_python/README.md
+++ b/agents/human_in_the_loop_python/README.md
@@ -49,14 +49,14 @@ temporal server start-dev
 
 In one terminal:
 ```bash
-uv run python -m worker
+uv run worker.py
 ```
 
 ### Start a Workflow
 
 In another terminal:
 ```bash
-uv run python -m start_workflow "Delete all test data from the production database"
+uv run start_workflow.py "Delete all test data from the production database"
 ```
 
 The Workflow will start, analyze the request, and pause for approval. Watch the Worker output for instructions.
@@ -67,12 +67,12 @@ The Worker output will show the Workflow Id and request identifier. In another t
 
 **To approve:**
 ```bash
-uv run python -m send_approval <workflow-id> <request-id> approve "Looks good"
+uv run send_approval.py <workflow-id> <request-id> approve "Looks good"
 ```
 
 **To reject:**
 ```bash
-uv run python -m send_approval <workflow-id> <request-id> reject "Too risky"
+uv run send_approval.py <workflow-id> <request-id> reject "Too risky"
 ```
 
 ### Testing timeout

--- a/agents/openai_agents_sdk_python/README.md
+++ b/agents/openai_agents_sdk_python/README.md
@@ -192,13 +192,13 @@ export OPENAI_API_KEY=sk...
 Run the worker:
 
 ```bash
-uv run python -m worker
+uv run worker.py
 ```
 
 Start execution:
 
 ```bash
-uv run python -m start_workflow
+uv run start_workflow.py
 ```
 
 ## Example interactions

--- a/agents/strands_agents_python/README.md
+++ b/agents/strands_agents_python/README.md
@@ -207,13 +207,13 @@ uv sync
 Run the Worker, with AWS credentials and region configured as described in the prerequisites:
 
 ```bash
-uv run python -m worker
+uv run worker.py
 ```
 
 In another terminal, start the Workflow:
 
 ```bash
-uv run python -m start_workflow
+uv run start_workflow.py
 ```
 
 ## Example interactions

--- a/agents/tool_call_openai_python/README.md
+++ b/agents/tool_call_openai_python/README.md
@@ -333,7 +333,7 @@ uv sync
 First set the `OPENAI_API_KEY` environment variable and then:
 
 ```bash
-uv run python -m worker
+uv run worker.py
 ```
 
 ### Initiate an interaction with the agent
@@ -341,11 +341,11 @@ uv run python -m worker
 This user input should not result in any tool call
 
 ```bash
-uv run python -m start_workflow "Tell me about recursion in programming."
+uv run start_workflow.py "Tell me about recursion in programming."
 ```
 
 This user input should invoke the tool and respond with current weather alerts for California.
 
 ```bash
-uv run python -m start_workflow "Are there any weather alerts in California?"
+uv run start_workflow.py "Are there any weather alerts in California?"
 ```

--- a/deep_research/basic_openai_python/README.md
+++ b/deep_research/basic_openai_python/README.md
@@ -528,17 +528,17 @@ temporal server start-dev
 Run the worker:
 
 ```bash
-uv run python -m worker
+uv run worker.py
 ```
 
 Start execution:
 
 ```bash
-uv run python -m start_workflow
+uv run start_workflow.py
 ```
 
 To start execution with a specific query:
 
 ```bash
-uv run python -m start_workflow "What is the latest news on the stock market?"
+uv run start_workflow.py "What is the latest news on the stock market?"
 ```

--- a/foundations/claim_check_pattern_python/README.md
+++ b/foundations/claim_check_pattern_python/README.md
@@ -467,12 +467,12 @@ temporal server start-dev
 
 3. Run the worker:
 ```bash
-uv run python -m worker
+uv run worker.py
 ```
 
 4. Start execution:
 ```bash
-uv run python -m start_workflow
+uv run start_workflow.py
 ```
 
 ### Option 2: AWS S3 (Production)
@@ -502,7 +502,7 @@ from aiohttp import hdrs, web
 from google.protobuf import json_format
 from temporalio.api.common.v1 import Payload, Payloads
 
-from .claim_check import ClaimCheckCodec
+from claim_check import ClaimCheckCodec
 
 def build_codec_server() -> web.Application:
     # Create codec with environment variable configuration (same as plugin)
@@ -630,7 +630,7 @@ if __name__ == "__main__":
 ### Running the codec server
 
 ```bash
-uv run python -m codec.codec_server
+uv run codec/codec_server.py
 ```
 
 Then [configure the Web UI to use the codec server](https://docs.temporal.io/production-deployment/data-encryption#set-your-codec-server-endpoints-with-web-ui-and-cli).

--- a/foundations/claim_check_pattern_python/codec/codec_server.py
+++ b/foundations/claim_check_pattern_python/codec/codec_server.py
@@ -7,7 +7,7 @@ from aiohttp import hdrs, web
 from google.protobuf import json_format
 from temporalio.api.common.v1 import Payload, Payloads
 
-from .claim_check import ClaimCheckCodec
+from claim_check import ClaimCheckCodec
 
 def build_codec_server() -> web.Application:
     # Create codec with environment variable configuration (same as plugin)

--- a/foundations/hello_world_litellm_python/README.md
+++ b/foundations/hello_world_litellm_python/README.md
@@ -230,11 +230,11 @@ Set the appropriate environment variables before launching the worker (for examp
 Run the worker:
 
 ```bash
-uv run python -m worker
+uv run worker.py
 ```
 
 Start the workflow:
 
 ```bash
-uv run python -m start_workflow
+uv run start_workflow.py
 ```

--- a/foundations/hello_world_openai_responses_python/README.md
+++ b/foundations/hello_world_openai_responses_python/README.md
@@ -186,11 +186,11 @@ temporal server start-dev
 Run the worker:
 
 ```bash
-uv run python -m worker
+uv run worker.py
 ```
 
 Start execution:
 
 ```bash
-uv run python -m start_workflow
+uv run start_workflow.py
 ```

--- a/foundations/http_retry_enhancement_python/README.md
+++ b/foundations/http_retry_enhancement_python/README.md
@@ -225,11 +225,11 @@ temporal server start-dev
 Run the worker:
 
 ```bash
-uv run python -m worker
+uv run worker.py
 ```
 
 Start execution:
 
 ```bash
-uv run python -m start_workflow
+uv run start_workflow.py
 ```

--- a/foundations/structured_output_openai_responses_python/README.md
+++ b/foundations/structured_output_openai_responses_python/README.md
@@ -277,11 +277,11 @@ temporal server start-dev
 Run the worker:
 
 ```bash
-uv run python -m worker
+uv run worker.py
 ```
 
 Start execution:
 
 ```bash
-uv run python -m start_workflow
+uv run start_workflow.py
 ```

--- a/mcp/hello_world_durable_mcp_server/README.md
+++ b/mcp/hello_world_durable_mcp_server/README.md
@@ -343,7 +343,7 @@ This recipe uses Temporal's environment configuration system to connect to Tempo
 
 3. Start the worker in one terminal:
    ```bash
-   uv run python worker.py
+   uv run worker.py
    ```
 
 4. Configure Claude Desktop by adding the configuration from `claude_desktop_config.json` to your Claude Desktop config file (typically located at `~/Library/Application Support/Claude/claude_desktop_config.json` on macOS).


### PR DESCRIPTION
Three small documentation fixes, plus the one code change needed to make the first of them uniform.

## Prefer `uv run worker.py` over `uv run python -m worker`

It is the form uv's own docs and `uv init` scaffold suggest, it is shorter, and it names the file the reader just saw in the recipe layout. Applied across 13 recipe READMEs and `CLAUDE.md`, covering `worker.py`, `start_workflow.py` (including the arg-passing forms), and `send_approval.py`. This also normalizes `mcp/hello_world_durable_mcp_server`, which had written `uv run python worker.py`.

Checked before converting: every entrypoint is a flat script with no relative imports, no recipe-root `__init__.py`, and no PEP 723 inline metadata (which would switch uv to an isolated env). Module resolution is unchanged — both forms put the recipe directory on `sys.path`.

## Make the claim check codec server runnable by path

`codec/codec_server.py` was the lone holdout: `from .claim_check import ...` only resolves under `-m`. Switched to a plain module import so it can be run as `uv run codec/codec_server.py`. `codec/plugin.py` keeps its relative import, since it is only ever imported as part of the package by `worker.py` and `start_workflow.py`, never run as a script.

## README rendering nits in the agentic-loop recipes

`*File: tools/__init__.py*` rendered as "File: tools/**init**.py" on docs.temporal.io — the `__` pairs parse as strong emphasis inside the surrounding italics. Escaped them. Also corrected "Open AI API" to "OpenAI API" and a missing space in `*File:start_workflow.py*`.

## Testing

- `uv run pytest tests/ --timeout=30` in `foundations/claim_check_pattern_python`: 17 passed.
- Started `uv run codec/codec_server.py` and confirmed it serves on 8081.
- Smoke-tested `uv run worker.py` in `foundations/hello_world_litellm_python`: resolves `workflows/` and `activities/` and reaches the Temporal connection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)