### PR TITLE
Fix temporalio 1.30 breakage in openai_agents_sdk_python and cover it with tests

### DIFF
--- a/agents/openai_agents_sdk_python/activities/tools.py
+++ b/agents/openai_agents_sdk_python/activities/tools.py
@@ -12,8 +12,6 @@ class Weather:
 @activity.defn
 async def get_weather(city: str) -> Weather:
     """Get the weather for a given city."""
-    # introduce a bug
-    raise Exception("This is a test error")
     return Weather(city=city, temperature_range="14-20C", conditions="Sunny with wind.")
 
 @activity.defn

--- a/agents/openai_agents_sdk_python/pyproject.toml
+++ b/agents/openai_agents_sdk_python/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.10"
 readme = "README.md"
 license = "MIT"
 dependencies = [
-    "temporalio>=1.15.0,<2",
+    "temporalio[opentelemetry]>=1.15.0,<2",
     "openai-agents>=0.1.0",
 ]
 

--- a/agents/openai_agents_sdk_python/start_workflow.py
+++ b/agents/openai_agents_sdk_python/start_workflow.py
@@ -24,7 +24,7 @@ async def main():
         user_input,
         id="my-workflow-id",
         task_queue="hello-world-openai-agent-task-queue",
-        id_conflict_policy=WorkflowIDConflictPolicy.TERMINATE_IF_RUNNING,
+        id_conflict_policy=WorkflowIDConflictPolicy.TERMINATE_EXISTING,
     )
     print(f"Result: {result}")
 

--- a/agents/openai_agents_sdk_python/tests/fakes.py
+++ b/agents/openai_agents_sdk_python/tests/fakes.py
@@ -1,0 +1,71 @@
+"""Shared fake Model/ModelProvider helpers for testing the OpenAI Agents SDK
+integration without making real network calls to OpenAI."""
+
+from agents.items import ModelResponse
+from agents.models.interface import Model, ModelProvider
+from agents.usage import Usage
+from openai.types.responses import (
+    ResponseFunctionToolCall,
+    ResponseOutputMessage,
+    ResponseOutputText,
+)
+
+
+def text_response(text: str, response_id: str = "resp_text") -> ModelResponse:
+    return ModelResponse(
+        output=[
+            ResponseOutputMessage(
+                id="msg_1",
+                type="message",
+                role="assistant",
+                status="completed",
+                content=[ResponseOutputText(type="output_text", text=text, annotations=[])],
+            )
+        ],
+        usage=Usage(),
+        response_id=response_id,
+    )
+
+
+def tool_call_response(
+    name: str, call_id: str, arguments: str, response_id: str = "resp_tool"
+) -> ModelResponse:
+    return ModelResponse(
+        output=[
+            ResponseFunctionToolCall(
+                id="fc_1",
+                type="function_call",
+                call_id=call_id,
+                name=name,
+                arguments=arguments,
+                status="completed",
+            )
+        ],
+        usage=Usage(),
+        response_id=response_id,
+    )
+
+
+class ScriptedModel(Model):
+    """Returns one canned ModelResponse per call, in order."""
+
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self._index = 0
+
+    async def get_response(self, *args, **kwargs):
+        response = self._responses[self._index]
+        self._index += 1
+        return response
+
+    async def stream_response(self, *args, **kwargs):
+        raise NotImplementedError("This recipe does not use streaming responses")
+        yield
+
+
+class ScriptedModelProvider(ModelProvider):
+    def __init__(self, model: Model):
+        self._model = model
+
+    def get_model(self, model_name):
+        return self._model

--- a/agents/openai_agents_sdk_python/tests/test_activities.py
+++ b/agents/openai_agents_sdk_python/tests/test_activities.py
@@ -30,10 +30,12 @@ class TestCalculateCircleArea:
 
 class TestGetWeather:
     @pytest.mark.asyncio
-    async def test_raises_exception(self):
+    async def test_returns_weather_for_city(self):
         env = ActivityEnvironment()
-        with pytest.raises(Exception, match="This is a test error"):
-            await env.run(get_weather, "New York")
+        result = await env.run(get_weather, "London")
+        assert result == Weather(
+            city="London", temperature_range="14-20C", conditions="Sunny with wind."
+        )
 
 
 class TestWeatherDataclass:

--- a/agents/openai_agents_sdk_python/tests/test_start_workflow.py
+++ b/agents/openai_agents_sdk_python/tests/test_start_workflow.py
@@ -1,0 +1,46 @@
+"""Tests for start_workflow.py — runs the actual submission script end-to-end
+against a scripted model provider, so a wiring mistake (e.g. a bad
+WorkflowIDConflictPolicy member, or a client/plugin misconfiguration) fails
+the way it would for a real user running `uv run start_workflow.py`."""
+
+from datetime import timedelta
+
+import pytest
+from temporalio.client import Client
+from temporalio.contrib.openai_agents import ModelActivityParameters, OpenAIAgentsPlugin
+from temporalio.testing import WorkflowEnvironment
+from temporalio.worker import Worker
+
+import start_workflow
+from activities.tools import calculate_circle_area, get_weather
+from fakes import ScriptedModel, ScriptedModelProvider, text_response
+from workflows.hello_world_workflow import HelloWorldAgent
+
+TASK_QUEUE = "hello-world-openai-agent-task-queue"
+
+
+class TestStartWorkflowScript:
+    @pytest.mark.asyncio
+    @pytest.mark.timeout(30)
+    async def test_main_submits_workflow_and_prints_result(self, monkeypatch, capsys):
+        plugin = OpenAIAgentsPlugin(
+            model_params=ModelActivityParameters(start_to_close_timeout=timedelta(seconds=10)),
+            model_provider=ScriptedModelProvider(ScriptedModel([text_response("Hello there!")])),
+        )
+        async with await WorkflowEnvironment.start_time_skipping(plugins=[plugin]) as env:
+
+            async def fake_connect(*args, **kwargs):
+                return env.client
+
+            monkeypatch.setattr(Client, "connect", fake_connect)
+            monkeypatch.setattr("builtins.input", lambda _: "Say hello")
+
+            async with Worker(
+                env.client,
+                task_queue=TASK_QUEUE,
+                workflows=[HelloWorldAgent],
+                activities=[get_weather, calculate_circle_area],
+            ):
+                await start_workflow.main()
+
+        assert "Result: Hello there!" in capsys.readouterr().out

--- a/agents/openai_agents_sdk_python/tests/test_workflow.py
+++ b/agents/openai_agents_sdk_python/tests/test_workflow.py
@@ -1,0 +1,78 @@
+"""Tests for HelloWorldAgent with a scripted model provider — no real OpenAI calls."""
+
+import json
+from datetime import timedelta
+
+import pytest
+from temporalio.contrib.openai_agents import ModelActivityParameters, OpenAIAgentsPlugin
+from temporalio.testing import WorkflowEnvironment
+from temporalio.worker import Worker
+
+from activities.tools import calculate_circle_area, get_weather
+from fakes import ScriptedModel, ScriptedModelProvider, text_response, tool_call_response
+from workflows.hello_world_workflow import HelloWorldAgent
+
+TASK_QUEUE = "test-hello-world-agent"
+
+
+async def _run_workflow(prompt: str, responses, workflow_id: str) -> str:
+    plugin = OpenAIAgentsPlugin(
+        model_params=ModelActivityParameters(start_to_close_timeout=timedelta(seconds=10)),
+        model_provider=ScriptedModelProvider(ScriptedModel(responses)),
+    )
+    async with await WorkflowEnvironment.start_time_skipping(plugins=[plugin]) as env:
+        async with Worker(
+            env.client,
+            task_queue=TASK_QUEUE,
+            workflows=[HelloWorldAgent],
+            activities=[get_weather, calculate_circle_area],
+        ):
+            return await env.client.execute_workflow(
+                HelloWorldAgent.run,
+                prompt,
+                id=workflow_id,
+                task_queue=TASK_QUEUE,
+                run_timeout=timedelta(seconds=30),
+            )
+
+
+class TestHelloWorldAgentTextOnly:
+    @pytest.mark.asyncio
+    @pytest.mark.timeout(30)
+    async def test_returns_text_when_no_tool_needed(self):
+        result = await _run_workflow(
+            "Say hello",
+            [text_response("Hello there!")],
+            "test-text-only",
+        )
+        assert result == "Hello there!"
+
+
+class TestHelloWorldAgentWeatherTool:
+    @pytest.mark.asyncio
+    @pytest.mark.timeout(30)
+    async def test_uses_get_weather_tool(self):
+        result = await _run_workflow(
+            "What's the weather in Tokyo?",
+            [
+                tool_call_response("get_weather", "call_1", json.dumps({"city": "Tokyo"})),
+                text_response("It's sunny in Tokyo, 14-20C."),
+            ],
+            "test-weather-tool",
+        )
+        assert "Tokyo" in result
+
+
+class TestHelloWorldAgentCircleAreaTool:
+    @pytest.mark.asyncio
+    @pytest.mark.timeout(30)
+    async def test_uses_calculate_circle_area_tool(self):
+        result = await _run_workflow(
+            "Calculate the area of a circle with radius 5",
+            [
+                tool_call_response("calculate_circle_area", "call_2", json.dumps({"radius": 5})),
+                text_response("The area is approximately 78.54 square units."),
+            ],
+            "test-circle-area-tool",
+        )
+        assert "78.54" in result

--- a/agents/openai_agents_sdk_python/uv.lock
+++ b/agents/openai_agents_sdk_python/uv.lock
@@ -288,7 +288,7 @@ version = "0.1"
 source = { virtual = "." }
 dependencies = [
     { name = "openai-agents" },
-    { name = "temporalio" },
+    { name = "temporalio", extra = ["opentelemetry"] },
 ]
 
 [package.dev-dependencies]
@@ -301,7 +301,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "openai-agents", specifier = ">=0.1.0" },
-    { name = "temporalio", specifier = ">=1.15.0,<2" },
+    { name = "temporalio", extras = ["opentelemetry"], specifier = ">=1.15.0,<2" },
 ]
 
 [package.metadata.requires-dev]
@@ -661,6 +661,45 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/05/0c/52e9aeff5549b225d5666a0eb84a8a22b4c47db08b6f44dbd45876fcfba3/openai_agents-0.18.2.tar.gz", hash = "sha256:9f418bb563eddff1e01f245ae8a4964b7649396f444b569b4113d105e41ca1d3", size = 5546139, upload-time = "2026-07-11T01:08:18.537Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9c/23/b5b6b80a3e36f021ca2a8c4637684f0d722d646b19d3616768a68802c302/openai_agents-0.18.2-py3-none-any.whl", hash = "sha256:c7aea341b256a90b87b17b7e444bab29a12655864a2f0094f65561223d867185", size = 874310, upload-time = "2026-07-11T01:08:16.851Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
+]
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/77/a6592cbc7c8d9bcc9d6757a9df45e04a7c585e3e6e7a13456da522b21109/opentelemetry_sdk-1.44.0.tar.gz", hash = "sha256:cebe7f65dc12f26ead75c6064de12fd2a9052e5060c0272d402cfa203aae123b", size = 208624, upload-time = "2026-07-16T15:25:46.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/23/ff077e61886ee020a17ce9c8b6fa11c601c8d8345b09ea24f605445df62a/opentelemetry_sdk-1.44.0-py3-none-any.whl", hash = "sha256:df081c4c6bcfdb1211e3e86140376792643128a25f8d72d1d27675936e7e96ad", size = 137221, upload-time = "2026-07-16T15:25:29.534Z" },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8f/73/0cbdebcb4cf545fdd328da14f5137e37d0770c3f26185e478b0d15d94f50/opentelemetry_semantic_conventions-0.65b0.tar.gz", hash = "sha256:f9b2b81e9d5b64f11bc952075e7e9c7fb0aab075c7fd1c46d597f1b919852d60", size = 148774, upload-time = "2026-07-16T15:25:46.902Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/0e/49df70d9b81fb5cbae4bbf2a49d865b09bcbcbc4eb53f5851b1027738d78/opentelemetry_semantic_conventions-0.65b0-py3-none-any.whl", hash = "sha256:1cacde7b0ad306f84c5ef08c3dbe1bbaf20165bba6f8bff43b670e555a086bcb", size = 204645, upload-time = "2026-07-16T15:25:30.688Z" },
 ]
 
 [[package]]
@@ -1322,6 +1361,12 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e6/57/dc648d812f4c688bd246a616f0d65c5f03b33675df2effb1b480e1df6d21/temporalio-1.30.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:108d1a56e174eabc18add58316084cdead230e239d3df22bbe999d6954986591", size = 14330502, upload-time = "2026-07-02T21:04:37.39Z" },
     { url = "https://files.pythonhosted.org/packages/1c/e1/dbd57de0f5090891850c2ee5490319834a12b704076b11f32a4a149998d4/temporalio-1.30.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47b156138de30c2cd6723d5bfc06a30abcf680344c5481abb31f2a98a9b1f809", size = 14833364, upload-time = "2026-07-02T21:04:40.454Z" },
     { url = "https://files.pythonhosted.org/packages/30/2a/6d41289c11465ba276a8b417f31d2e469f0fe4b8afacd61d5244151c5fce/temporalio-1.30.0-cp310-abi3-win_amd64.whl", hash = "sha256:3adee28d5ec47bd6309a5eeef7b00126373f119bc5c1b058a34de098542f4da7", size = 15181893, upload-time = "2026-07-02T21:04:43.609Z" },
+]
+
+[package.optional-dependencies]
+opentelemetry = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-sdk" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

While reviewing dependabot PR #194 against `main`, testing surfaced two pre-existing bugs in `agents/openai_agents_sdk_python/` that break the recipe for anyone following the README today. Both slipped through the temporalio 1.30 upgrade in #192 because the existing test suite only unit-tests the two activity functions directly — it never imports `temporalio.contrib.openai_agents` or runs `worker.py`/`start_workflow.py`.

- **Missing dependency**: `temporalio==1.30.0`'s `temporalio.contrib.openai_agents` module unconditionally imports `temporalio.contrib.opentelemetry`, but this recipe's `pyproject.toml` didn't declare the `opentelemetry` extra. `uv run worker.py` failed with `ModuleNotFoundError: No module named 'opentelemetry'`.
- **Wrong enum member**: `start_workflow.py` used `WorkflowIDConflictPolicy.TERMINATE_IF_RUNNING`, which doesn't exist in temporalio 1.30 — the correct member is `TERMINATE_EXISTING`. This raised `AttributeError` before the workflow even started.
- **Unrelated pre-existing bug**: `activities/tools.py`'s `get_weather` had a stray `raise Exception("This is a test error")` that always broke the weather tool. The README's documented code sample never had this line — it looks like leftover debug code from an unrelated PR.

## Changes

- Add `temporalio[opentelemetry]` to `pyproject.toml`/`uv.lock`.
- Fix the `WorkflowIDConflictPolicy` member in `start_workflow.py`.
- Remove the stray `raise Exception` in `get_weather`.
- Add `tests/fakes.py`: a scripted `Model`/`ModelProvider` for the OpenAI Agents SDK, so workflow tests run fully offline with no `OPENAI_API_KEY` and no real network calls.
- Add `tests/test_workflow.py`: exercises `HelloWorldAgent` through `WorkflowEnvironment` + `Worker` with the real `OpenAIAgentsPlugin` wiring, covering the text-only, `get_weather`, and `calculate_circle_area` paths.
- Add `tests/test_start_workflow.py`: runs `start_workflow.main()` itself against a scripted model so the `id_conflict_policy` line is actually exercised, not just imported.
- Update `tests/test_activities.py`: replace the test that asserted `get_weather` *fails* with one asserting it returns correct data.

## Test plan

- [x] `uv sync && uv run pytest tests/ --timeout=30` — all 9 tests pass.
- [x] Verified both new-test regressions independently: reverting `TERMINATE_EXISTING` → `TERMINATE_IF_RUNNING` fails `test_start_workflow.py` with the original `AttributeError`; uninstalling `opentelemetry-*` fails `test_workflow.py`/`test_start_workflow.py` at collection with the original `ModuleNotFoundError` — this is the exact failure mode CI's `pytest tests/` step would now catch.
- [x] Full manual end-to-end run with a real `OPENAI_API_KEY`: `temporal server start-dev` → `worker.py` → `start_workflow.py`, asked "What is the capital of France?", got back "Paris."

🤖 Generated with [Claude Code](https://claude.com/claude-code)