### PR TITLE
Bump AI SDK recipe to ai v7

### DIFF
--- a/agents/ai_sdk_by_vercel_typescript/README.md
+++ b/agents/ai_sdk_by_vercel_typescript/README.md
@@ -10,7 +10,7 @@ In this example, we show you how to build a durable agent using the [AI SDK by V
 
 This recipe highlights key implementation patterns:
 
-- **AI SDK client integration**: The Workflow uses `generateText` from `ai` and `temporalProvider` from `@temporalio/ai-sdk`. This automatically wraps the LLM invocation as an Activity, so it's retried and tracked like any other durable step. `temporalProvider` is configured for `gpt-4o-mini` here, but you can point it at any model the AI SDK supports.
+- **AI SDK client integration**: The Workflow uses `generateText` from `ai` and `temporalProvider` from `@temporalio/ai-sdk/workflow`. This automatically wraps the LLM invocation as an Activity, so it's retried and tracked like any other durable step. `temporalProvider` is configured for `gpt-4o-mini` here, but you can point it at any model the AI SDK supports.
 - **Tools-as-Activities**: `proxyActivities` wires the `getWeather` and `calculateAreaOfCircle` Activities into the Workflow so `toolsAgent` can offer tool schemas to the model, wait for results durably, and retry a tool call if it fails.
 
 Unlike some other Temporal AI integrations — for example, the OpenAI Agents SDK's `activity_as_tool` helper, which generates a tool schema from a Python function's type hints — the Vercel AI SDK's `tool()` has no equivalent auto-generation from a TypeScript function signature. Each tool's `inputSchema` is written by hand as a Zod schema.
@@ -78,15 +78,14 @@ export async function calculateAreaOfCircle(input: { radius: number }): Promise<
 
 ## Create the Workflow
 
-The Workflow registers both Activities as tools with a Zod schema so the model can call them when appropriate.
+The Workflow registers both Activities as tools with a Zod schema so the model can call them when appropriate. Workflow code imports `temporalProvider` from `@temporalio/ai-sdk/workflow` rather than the package root, because the root also exports the Worker-side Activities and plugin, whose imports the Workflow bundler disallows.
 
 *File: src/workflows.ts*
 
 ```ts
-import '@temporalio/ai-sdk/lib/load-polyfills';
 import type * as activities from './activities';
 import { generateText, stepCountIs, tool } from 'ai';
-import { temporalProvider } from '@temporalio/ai-sdk';
+import { temporalProvider } from '@temporalio/ai-sdk/workflow';
 import { proxyActivities } from '@temporalio/workflow';
 import z from 'zod';
 
@@ -191,6 +190,8 @@ run().catch((err) => {
 ```
 
 ## Running
+
+This recipe needs Node 22.12 or later. The AI SDK is ESM-only as of v7, and this project is CommonJS, so it relies on Node's support for `require()` of ESM modules.
 
 Start the Temporal Dev Server:
 ```bash

--- a/agents/ai_sdk_by_vercel_typescript/README.md
+++ b/agents/ai_sdk_by_vercel_typescript/README.md
@@ -78,7 +78,7 @@ export async function calculateAreaOfCircle(input: { radius: number }): Promise<
 
 ## Create the Workflow
 
-The Workflow registers both Activities as tools with a Zod schema so the model can call them when appropriate. Workflow code imports `temporalProvider` from `@temporalio/ai-sdk/workflow` rather than the package root, because the root also exports the Worker-side Activities and plugin, whose imports the Workflow bundler disallows.
+The Workflow registers both Activities as tools with a Zod schema so the model can call them when appropriate.
 
 *File: src/workflows.ts*
 
@@ -191,7 +191,6 @@ run().catch((err) => {
 
 ## Running
 
-This recipe needs Node 22.12 or later. The AI SDK is ESM-only as of v7, and this project is CommonJS, so it relies on Node's support for `require()` of ESM modules.
 
 Start the Temporal Dev Server:
 ```bash

--- a/agents/ai_sdk_by_vercel_typescript/README.md
+++ b/agents/ai_sdk_by_vercel_typescript/README.md
@@ -191,7 +191,6 @@ run().catch((err) => {
 
 ## Running
 
-
 Start the Temporal Dev Server:
 ```bash
 temporal server start-dev

--- a/agents/ai_sdk_by_vercel_typescript/package-lock.json
+++ b/agents/ai_sdk_by_vercel_typescript/package-lock.json
@@ -8,19 +8,19 @@
       "name": "temporal-ai-sdk-by-vercel-typescript-cookbook",
       "version": "0.1.0",
       "dependencies": {
-        "@ai-sdk/openai": "^3.0.0",
-        "@ai-sdk/provider": "^3.0.0",
-        "@temporalio/ai-sdk": "^1.14.1",
-        "@temporalio/client": "^1.14.1",
-        "@temporalio/envconfig": "^1.14.1",
-        "@temporalio/worker": "^1.14.1",
-        "@temporalio/workflow": "^1.14.1",
-        "ai": "^6.0.0",
+        "@ai-sdk/openai": "^4.0.0",
+        "@ai-sdk/provider": "^4.0.0",
+        "@temporalio/ai-sdk": "^1.22.0",
+        "@temporalio/client": "^1.22.0",
+        "@temporalio/envconfig": "^1.22.0",
+        "@temporalio/worker": "^1.22.0",
+        "@temporalio/workflow": "^1.22.0",
+        "ai": "^7.0.0",
         "nanoid": "3.x",
         "zod": "^3.25.76"
       },
       "devDependencies": {
-        "@tsconfig/node18": "^18.2.4",
+        "@tsconfig/node22": "^22.0.5",
         "@types/node": "^22.9.1",
         "@typescript-eslint/eslint-plugin": "^8.18.0",
         "@typescript-eslint/parser": "^8.18.0",
@@ -30,84 +30,89 @@
         "nodemon": "^3.1.7",
         "prettier": "^3.4.2",
         "ts-node": "^10.9.2",
-        "typescript": "^5.6.3"
+        "typescript": "^5.9.3"
+      },
+      "engines": {
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@ai-sdk/gateway": {
-      "version": "3.0.16",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.16.tgz",
-      "integrity": "sha512-OOY5CfRJiHvh/8np2vs1RQaCZ5hWv2qOeEmmeiABXK3gLQHUVnCO+1hhoLsZdHM5iElu6M407dAOfyvTsKJqcQ==",
+      "version": "4.0.52",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-4.0.52.tgz",
+      "integrity": "sha512-SXUM8jzzuTUJRq+EOgPd5to6DSx0EKslVn+IVZHbUEX6k/3vCPNrvjckbK26HnNxHU/STxm+zTSJteqrO+7Z0w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.4",
-        "@ai-sdk/provider-utils": "4.0.8",
-        "@vercel/oidc": "3.1.0"
+        "@ai-sdk/provider": "4.0.7",
+        "@ai-sdk/provider-utils": "5.0.27",
+        "@vercel/oidc": "3.2.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@ai-sdk/mcp": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/mcp/-/mcp-1.0.10.tgz",
-      "integrity": "sha512-8/+l5oO/8jGXLD5Ddns6pDVO9AW5GEPB9jZ+vWkSKoBjHJlfdyHRXvonqLrJPitzPAoAixwqoRKCWNcctIZm9w==",
+      "version": "2.0.31",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/mcp/-/mcp-2.0.31.tgz",
+      "integrity": "sha512-vBxkIg4CB9wQjWYo5uu1G/Vv3Xhbi3JZ47HoT5ywLNTycxKlY2RGGynTyGqcXLcvWBErRyMygDYVFn8VPc1N+w==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@ai-sdk/provider": "3.0.4",
-        "@ai-sdk/provider-utils": "4.0.8",
-        "pkce-challenge": "^5.0.0"
+        "@ai-sdk/provider": "4.0.7",
+        "@ai-sdk/provider-utils": "5.0.27",
+        "pkce-challenge": "^5.0.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@ai-sdk/openai": {
-      "version": "3.0.12",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.12.tgz",
-      "integrity": "sha512-zqLWEKuaKnjXhu7xCw1jgz/+yTbd3F7EtgU4T2Q8BAo8OJC5wZv14l+kwM7Jai7M1/2Y2T/zBkrfiIu+7NsvfQ==",
+      "version": "4.0.41",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-4.0.41.tgz",
+      "integrity": "sha512-+WoY0JyF/uV2z+rye7I+hYaVg+hTanG4rYIgsWKvJFDXaAdu9yg07x+BRa2vTgUqzLIBXEBp5d1T7DwMI9ZGlw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.4",
-        "@ai-sdk/provider-utils": "4.0.8"
+        "@ai-sdk/provider": "4.0.7",
+        "@ai-sdk/provider-utils": "5.0.27"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@ai-sdk/provider": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.4.tgz",
-      "integrity": "sha512-5KXyBOSEX+l67elrEa+wqo/LSsSTtrPj9Uoh3zMbe/ceQX4ucHI3b9nUEfNkGF3Ry1svv90widAt+aiKdIJasQ==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.7.tgz",
+      "integrity": "sha512-6or44XprPzKbr8zkmzosowSE0pxkvJcoojBL+mCZvPUt3kvXp3XSNqeVun9golb1acEfSo6yaEBRT18h2VU+1Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "json-schema": "^0.4.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       }
     },
     "node_modules/@ai-sdk/provider-utils": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.8.tgz",
-      "integrity": "sha512-ns9gN7MmpI8vTRandzgz+KK/zNMLzhrriiKECMt4euLtQFSBgNfydtagPOX4j4pS1/3KvHF6RivhT3gNQgBZsg==",
+      "version": "5.0.27",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.27.tgz",
+      "integrity": "sha512-EzAn4pdgG5g0xXtH6lE2zyNmfjDQIDjATkfqzuidEI35g++hh4+07vnjzkT/RmGmIClPZiRj/Q2GMPV2V7mkHw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.4",
+        "@ai-sdk/provider": "4.0.7",
         "@standard-schema/spec": "^1.1.0",
-        "eventsource-parser": "^3.0.6"
+        "@workflow/serde": "4.1.0",
+        "eventsource-parser": "^3.0.8",
+        "undici": "^7.28.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
@@ -544,15 +549,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@opentelemetry/api": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
-      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -566,37 +562,30 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
+        "@protobufjs/aspromise": "^1.1.1"
       }
     },
     "node_modules/@protobufjs/float": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
@@ -612,9 +601,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@standard-schema/spec": {
@@ -837,182 +826,200 @@
       }
     },
     "node_modules/@temporalio/activity": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@temporalio/activity/-/activity-1.14.1.tgz",
-      "integrity": "sha512-wG2fTNgomhcKOzPY7mqhKqe8scawm4BvUYdgX1HJouHmVNRgtZurf2xQWJZQOTxWrsXfdoYqzohZLzxlNtcC5A==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@temporalio/activity/-/activity-1.22.0.tgz",
+      "integrity": "sha512-hrPeELIMloFWVrwmDfG1lh3uFNkaYp1ZHpcpWmJniTeSyxqCqLdil4lBOv11FByb6HeKxE6rsvOOUohulyVhRg==",
       "license": "MIT",
       "dependencies": {
-        "@temporalio/client": "1.14.1",
-        "@temporalio/common": "1.14.1",
-        "abort-controller": "^3.0.0"
+        "@temporalio/client": "1.22.0",
+        "@temporalio/common": "1.22.0"
       },
       "engines": {
-        "node": ">= 18.0.0"
+        "node": ">= 20.3.0"
       }
     },
     "node_modules/@temporalio/ai-sdk": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@temporalio/ai-sdk/-/ai-sdk-1.14.1.tgz",
-      "integrity": "sha512-4zZaWQRU6EadkE8UEQ3vjal2tiKCVSDY6KOtayS8zRGXijs2gLCopwnMm0mrfd9DPfzoeCK2hWDMtYPPzRGwrQ==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@temporalio/ai-sdk/-/ai-sdk-1.22.0.tgz",
+      "integrity": "sha512-Nq5xWDhVuuuUHf231uNDJtjdDjjQUQggIhg0B1EtSNCZJFEl8jMLr/18CbCWzKmTo1rhYm5Nwg6hl2ibuv7EKQ==",
       "license": "MIT",
       "dependencies": {
-        "@temporalio/plugin": "1.14.1",
-        "@temporalio/workflow": "1.14.1",
-        "@ungap/structured-clone": "^1.3.0",
+        "@temporalio/activity": "1.22.0",
+        "@temporalio/client": "1.22.0",
+        "@temporalio/common": "1.22.0",
+        "@temporalio/plugin": "1.22.0",
+        "@temporalio/workflow": "1.22.0",
+        "@temporalio/workflow-streams": "1.22.0",
+        "@ungap/structured-clone": "^1.3.1",
         "headers-polyfill": "^4.0.3",
         "web-streams-polyfill": "^4.2.0"
       },
       "engines": {
-        "node": ">= 18.0.0"
+        "node": ">= 22.12.0"
       },
       "peerDependencies": {
-        "@ai-sdk/mcp": "^1.0.0",
-        "@ai-sdk/provider": "^3.0.0",
-        "ai": "^6.0.0"
+        "@ai-sdk/mcp": "^2.0.0",
+        "@ai-sdk/provider": "^4.0.0",
+        "ai": "^7.0.0"
       }
     },
     "node_modules/@temporalio/client": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@temporalio/client/-/client-1.14.1.tgz",
-      "integrity": "sha512-AfWSA0LYzBvDLFiFgrPWqTGGq1NGnF3d4xKnxf0PGxSmv5SLb/aqQ9lzHg4DJ5UNkHO4M/NwzdxzzoaR1J5F8Q==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@temporalio/client/-/client-1.22.0.tgz",
+      "integrity": "sha512-b02ty0uDly6/ZRKlbavs5GjXVTry/GB4tkq0v1NH4H7x+nTo/OK0u5Ms8Nni8D+aar3xff9lzIpXNwu/Dp3P3w==",
       "license": "MIT",
       "dependencies": {
         "@grpc/grpc-js": "^1.12.4",
-        "@temporalio/common": "1.14.1",
-        "@temporalio/proto": "1.14.1",
+        "@temporalio/common": "1.22.0",
+        "@temporalio/proto": "1.22.0",
         "abort-controller": "^3.0.0",
         "long": "^5.2.3",
+        "nexus-rpc": "^0.0.2",
         "uuid": "^11.1.0"
       },
       "engines": {
-        "node": ">= 18.0.0"
+        "node": ">= 20.3.0"
       }
     },
     "node_modules/@temporalio/common": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@temporalio/common/-/common-1.14.1.tgz",
-      "integrity": "sha512-y49wOm3AIEKZufIQ/QU5JhTSaHJIEkiUt5bGB0/uSzCg8P4g8Cz0XoVPSbDwuCix533O9cOKcliYq7Gzjt/sIA==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@temporalio/common/-/common-1.22.0.tgz",
+      "integrity": "sha512-1NpQpo/y6XU1ULbo/bXgBEhl6qQnOeB79NrsSJdjI38/hfXPom2IYGJcIxOFfsQICQ0zePEKzB9Yyo31KNpIxA==",
       "license": "MIT",
       "dependencies": {
-        "@temporalio/proto": "1.14.1",
+        "@temporalio/proto": "1.22.0",
         "long": "^5.2.3",
         "ms": "3.0.0-canary.1",
-        "nexus-rpc": "^0.0.1",
+        "nexus-rpc": "^0.0.2",
         "proto3-json-serializer": "^2.0.0"
       },
       "engines": {
-        "node": ">= 18.0.0"
+        "node": ">= 20.3.0"
       }
     },
     "node_modules/@temporalio/core-bridge": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@temporalio/core-bridge/-/core-bridge-1.14.1.tgz",
-      "integrity": "sha512-mrXXIFK5yNvsSZsTejLnL64JMuMliQjFKktSGITm2Ci7cWZ/ZTOVN6u+hCsUKfadYYv83jSuOC9Xe3z3RK273w==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@temporalio/core-bridge/-/core-bridge-1.22.0.tgz",
+      "integrity": "sha512-mJ5agqtfW+GBPYl+ivYLrBpKJ3oFOw8ogcoizNrxYCzwJeprGFiEgHDb/jzyvECR4HAy5s9zQFJYNyTruXXFMw==",
       "license": "MIT",
       "dependencies": {
         "@grpc/grpc-js": "^1.12.4",
-        "@temporalio/common": "1.14.1"
+        "@temporalio/common": "1.22.0"
       },
       "engines": {
-        "node": ">= 18.0.0"
+        "node": ">= 20.3.0"
       }
     },
     "node_modules/@temporalio/envconfig": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@temporalio/envconfig/-/envconfig-1.14.1.tgz",
-      "integrity": "sha512-KAzxQtA6gqo8Lxto39ECD72Cpnsj9mzQ69TMeya4nXa0/K6G2ZOmo3bJ0DGmPzBl/c0u9fuYB9gs9uZAadpoVQ==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@temporalio/envconfig/-/envconfig-1.22.0.tgz",
+      "integrity": "sha512-7ZfLINqHBtkL+9ZqfD0T9ONl0RpFo8N5/DxGLRACC1MwaNta2ZJNr4E3fz3uKcd6Fz32WZPxAfTNbKiSy6JJlA==",
       "license": "MIT",
       "dependencies": {
-        "@temporalio/common": "1.14.1",
-        "smol-toml": "1.4.2"
+        "@temporalio/common": "1.22.0",
+        "smol-toml": "^1.6.1"
       },
       "engines": {
-        "node": ">= 18.0.0"
+        "node": ">= 20.3.0"
       }
     },
     "node_modules/@temporalio/nexus": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@temporalio/nexus/-/nexus-1.14.1.tgz",
-      "integrity": "sha512-51oTeJ8nntAMF8boFSlzVdHlyC7y/LaLQPZMjEEOV2pi8O9yOI7GZvYDIAHhY8Z8AcDVgbXb8x0BbkjkwNiUiQ==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@temporalio/nexus/-/nexus-1.22.0.tgz",
+      "integrity": "sha512-4S1ZZdSNjrO9IUyhWxweIidvNn1X/ihEl+P2fOn/Ky38YRx9G+8wtV6g6lqG8zUrtEv//uqFw+HsRMziE2y4tg==",
       "license": "MIT",
       "dependencies": {
-        "@temporalio/client": "1.14.1",
-        "@temporalio/common": "1.14.1",
-        "@temporalio/proto": "1.14.1",
+        "@temporalio/client": "1.22.0",
+        "@temporalio/common": "1.22.0",
+        "@temporalio/proto": "1.22.0",
         "long": "^5.2.3",
-        "nexus-rpc": "^0.0.1"
+        "nexus-rpc": "^0.0.2"
       },
       "engines": {
-        "node": ">= 18.0.0"
+        "node": ">= 20.3.0"
       }
     },
     "node_modules/@temporalio/plugin": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@temporalio/plugin/-/plugin-1.14.1.tgz",
-      "integrity": "sha512-YWoBfqxo21LZd8oEZrrInwL3kfofAq2sUwImwzLRdfk/4id62noA4Z6EcTHkYzpRmYBVnI38cikJVdTuKt3/Ew==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@temporalio/plugin/-/plugin-1.22.0.tgz",
+      "integrity": "sha512-7qp5mUTBMnCM8J9vJGIpO5uj57fWpbaJz4/lN0jSKg87aXhUlvkRHzSMVtBX27KFQdNtK9/ieCWyj7tTs6VF/Q==",
       "license": "MIT",
       "engines": {
-        "node": ">= 18.0.0"
+        "node": ">= 20.3.0"
       }
     },
     "node_modules/@temporalio/proto": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@temporalio/proto/-/proto-1.14.1.tgz",
-      "integrity": "sha512-mCsUommDPXbXbBu60p1g4jpSqVb+GNR67yR0uKTU8ARb4qVZQo7SQnOUaneoxDERDXuR/yIjVCektMm+7Myb+A==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@temporalio/proto/-/proto-1.22.0.tgz",
+      "integrity": "sha512-X7NVa0Z6HK3l9irZR48FKwZ9w9YXetCdF2z2KCIRr0W7Kul64Wt9o5hwvSXShAtrZuCEEHH8WO/ffHTXxJieLg==",
       "license": "MIT",
       "dependencies": {
         "long": "^5.2.3",
-        "protobufjs": "^7.2.5"
+        "protobufjs": "^7.6.4"
       },
       "engines": {
-        "node": ">= 18.0.0"
+        "node": ">= 20.3.0"
       }
     },
     "node_modules/@temporalio/worker": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@temporalio/worker/-/worker-1.14.1.tgz",
-      "integrity": "sha512-wFfN5gc03eq1bYAuJNsG9a1iWBG6hL9zAfYbxiJdshPhpHa82BtHGvXD447oT2BX3zqI+Jf2b0m/N0wgkW6wyQ==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@temporalio/worker/-/worker-1.22.0.tgz",
+      "integrity": "sha512-axRHhUsovFlqDtXZxUnhRLV7WmC6qOMUCij13lw4glT5yRH62k8wIZqcT3naEfvLSzoDxjt2xM7me3VvTRSaow==",
       "license": "MIT",
       "dependencies": {
         "@grpc/grpc-js": "^1.12.4",
         "@swc/core": "^1.3.102",
-        "@temporalio/activity": "1.14.1",
-        "@temporalio/client": "1.14.1",
-        "@temporalio/common": "1.14.1",
-        "@temporalio/core-bridge": "1.14.1",
-        "@temporalio/nexus": "1.14.1",
-        "@temporalio/proto": "1.14.1",
-        "@temporalio/workflow": "1.14.1",
-        "abort-controller": "^3.0.0",
+        "@temporalio/activity": "1.22.0",
+        "@temporalio/client": "1.22.0",
+        "@temporalio/common": "1.22.0",
+        "@temporalio/core-bridge": "1.22.0",
+        "@temporalio/nexus": "1.22.0",
+        "@temporalio/proto": "1.22.0",
+        "@temporalio/workflow": "1.22.0",
         "heap-js": "^2.6.0",
         "memfs": "^4.6.0",
-        "nexus-rpc": "^0.0.1",
-        "proto3-json-serializer": "^2.0.0",
-        "protobufjs": "^7.2.5",
+        "nexus-rpc": "^0.0.2",
+        "protobufjs": "^7.6.4",
         "rxjs": "^7.8.1",
         "source-map": "^0.7.4",
-        "source-map-loader": "^4.0.2",
+        "source-map-loader": "^5.0.0",
         "supports-color": "^8.1.1",
         "swc-loader": "^0.2.3",
         "unionfs": "^4.5.1",
-        "webpack": "^5.94.0"
+        "webpack": "^5.108.4"
       },
       "engines": {
-        "node": ">= 18.0.0"
+        "node": ">= 20.3.0"
       }
     },
     "node_modules/@temporalio/workflow": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@temporalio/workflow/-/workflow-1.14.1.tgz",
-      "integrity": "sha512-MzshcoRo8zjQYa9WHrv3XC8LVvpRNSVaW3kOSTmHuTYDh/7be48WODOgs5yUpbnkpsw6rjVCDCgtB/K02cQwDg==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@temporalio/workflow/-/workflow-1.22.0.tgz",
+      "integrity": "sha512-31Ax529+TvfH2RCexOhiCyM3lARJJoVzrnRUS1gX+jl+mka+pRRnEUx4B572mZz0oOlCCxbiztHZF72wwwWZDA==",
       "license": "MIT",
       "dependencies": {
-        "@temporalio/common": "1.14.1",
-        "@temporalio/proto": "1.14.1",
-        "nexus-rpc": "^0.0.1"
+        "@temporalio/common": "1.22.0",
+        "@temporalio/proto": "1.22.0",
+        "nexus-rpc": "^0.0.2"
       },
       "engines": {
-        "node": ">= 18.0.0"
+        "node": ">= 20.3.0"
+      }
+    },
+    "node_modules/@temporalio/workflow-streams": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@temporalio/workflow-streams/-/workflow-streams-1.22.0.tgz",
+      "integrity": "sha512-PApGT3qVAweB/eiZ3lVnNqhUONng9RUMhxHVMBOe4j4cUsv4Af9tYvShdSUdTSt7dFSooav8uyCmthM+T/HP4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@temporalio/activity": "1.22.0",
+        "@temporalio/client": "1.22.0",
+        "@temporalio/common": "1.22.0",
+        "@temporalio/proto": "1.22.0",
+        "@temporalio/workflow": "1.22.0"
+      },
+      "engines": {
+        "node": ">= 20.3.0"
       }
     },
     "node_modules/@tsconfig/node10": {
@@ -1043,37 +1050,17 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@tsconfig/node18": {
-      "version": "18.2.6",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node18/-/node18-18.2.6.tgz",
-      "integrity": "sha512-eAWQzAjPj18tKnDzmWstz4OyWewLUNBm9tdoN9LayzoboRktYx3Enk1ZXPmThj55L7c4VWYq/Bzq0A51znZfhw==",
+    "node_modules/@tsconfig/node22": {
+      "version": "22.0.5",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node22/-/node22-22.0.5.tgz",
+      "integrity": "sha512-hLf2ld+sYN/BtOJjHUWOk568dvjFQkHnLNa6zce25GIH+vxKfvTgm3qpaH6ToF5tu/NN0IH66s+Bb5wElHrLcw==",
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/eslint": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
-      "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "*",
-        "@types/json-schema": "*"
-      }
-    },
-    "node_modules/@types/eslint-scope": {
-      "version": "3.7.7",
-      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
-      "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/eslint": "*",
-        "@types/estree": "*"
-      }
-    },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
@@ -1325,15 +1312,15 @@
       }
     },
     "node_modules/@ungap/structured-clone": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
-      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
+      "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
       "license": "ISC"
     },
     "node_modules/@vercel/oidc": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.1.0.tgz",
-      "integrity": "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 20"
@@ -1485,6 +1472,12 @@
         "@xtuc/long": "4.2.2"
       }
     },
+    "node_modules/@workflow/serde": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@workflow/serde/-/serde-4.1.0.tgz",
+      "integrity": "sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -1510,27 +1503,15 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/acorn-import-phases": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
-      "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "peerDependencies": {
-        "acorn": "^8.14.0"
       }
     },
     "node_modules/acorn-jsx": {
@@ -1557,18 +1538,17 @@
       }
     },
     "node_modules/ai": {
-      "version": "6.0.39",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.39.tgz",
-      "integrity": "sha512-hF05gF4H+IxuilA8kNANVVHQXduTJsJaH74jmlmy8mcQt3NZgPYe2zZNyGBV4DPDYTUDt1h31hbLgQqJTn5LGA==",
+      "version": "7.0.65",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-7.0.65.tgz",
+      "integrity": "sha512-Uzom971mOHETL9tbeCWDEgbAA/Banj0KnR2obNEWPEUlGnAv2NJjFIxrUZ6F0XxHFDgGVVpnz86BB2CPOZZ83g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/gateway": "3.0.16",
-        "@ai-sdk/provider": "3.0.4",
-        "@ai-sdk/provider-utils": "4.0.8",
-        "@opentelemetry/api": "1.9.0"
+        "@ai-sdk/gateway": "4.0.52",
+        "@ai-sdk/provider": "4.0.7",
+        "@ai-sdk/provider-utils": "5.0.27"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
@@ -1609,9 +1589,9 @@
       }
     },
     "node_modules/ajv-formats/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -2038,22 +2018,22 @@
       "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.18.4",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.4.tgz",
-      "integrity": "sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q==",
+      "version": "5.24.5",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.5.tgz",
+      "integrity": "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==",
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
-        "tapable": "^2.2.0"
+        "tapable": "^2.3.3"
       },
       "engines": {
         "node": ">=10.13.0"
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
-      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
       "license": "MIT"
     },
     "node_modules/escalade": {
@@ -2424,9 +2404,9 @@
       }
     },
     "node_modules/eventsource-parser": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
-      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.1.tgz",
+      "integrity": "sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -2660,12 +2640,6 @@
       "peerDependencies": {
         "tslib": "2"
       }
-    },
-    "node_modules/glob-to-regexp": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-      "license": "BSD-2-Clause"
     },
     "node_modules/glob/node_modules/brace-expansion": {
       "version": "1.1.12",
@@ -2965,12 +2939,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/json-parse-even-better-errors": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "license": "MIT"
-    },
     "node_modules/json-schema": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
@@ -3013,19 +2981,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/loader-runner": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.1.tgz",
-      "integrity": "sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.11.5"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/locate-path": {
@@ -3119,22 +3074,10 @@
       }
     },
     "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
       "engines": {
         "node": ">= 0.6"
       }
@@ -3153,6 +3096,76 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimizer-webpack-plugin": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/minimizer-webpack-plugin/-/minimizer-webpack-plugin-5.6.1.tgz",
+      "integrity": "sha512-DoeAZz8Q1C1znwsUzej1fdoi4jCf7/+Em27ouLqfK/+3m8G+D7yDhUwrc3CNhjSzGUN1kn7Iv4sWmjflQHenpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "jest-worker": "^27.4.5",
+        "schema-utils": "^4.3.0",
+        "terser": "^5.31.1"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@minify-html/node": {
+          "optional": true
+        },
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/css": {
+          "optional": true
+        },
+        "@swc/html": {
+          "optional": true
+        },
+        "clean-css": {
+          "optional": true
+        },
+        "cssnano": {
+          "optional": true
+        },
+        "csso": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "html-minifier-terser": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "uglify-js": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/minimizer-webpack-plugin/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "node_modules/ms": {
@@ -3196,12 +3209,12 @@
       "license": "MIT"
     },
     "node_modules/nexus-rpc": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/nexus-rpc/-/nexus-rpc-0.0.1.tgz",
-      "integrity": "sha512-hAWn8Hh2eewpB5McXR5EW81R3pR/ziuGhKCF3wFyUVCklanPqrIgMNr7jKCbzXeNVad0nUDfWpFRqh2u+zxQtw==",
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/nexus-rpc/-/nexus-rpc-0.0.2.tgz",
+      "integrity": "sha512-IWjIExdVYlmwXuzHdY/Q3lXCv1gbqoAXPazQhy2w4Xgtgha3H0OOujEESVPQcFUFMWm+pAk2gKnb57g8S41JZg==",
       "license": "MIT",
       "engines": {
-        "node": ">= 18.0.0"
+        "node": ">= 20.0.0"
       }
     },
     "node_modules/node-releases": {
@@ -3477,24 +3490,23 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
+        "long": "^5.3.2"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -3537,15 +3549,6 @@
         }
       ],
       "license": "MIT"
-    },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
@@ -3649,26 +3652,6 @@
         "tslib": "^2.1.0"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -3695,9 +3678,9 @@
       }
     },
     "node_modules/schema-utils/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -3739,15 +3722,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
       }
     },
     "node_modules/shebang-command": {
@@ -3797,9 +3771,9 @@
       }
     },
     "node_modules/smol-toml": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.4.2.tgz",
-      "integrity": "sha512-rInDH6lCNiEyn3+hH8KVGFdbjc099j47+OSgbMrfDYX1CmXLfdKd7qi6IfcWj2wFxvSVkuI46M+wPGYfEOEj6g==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.8.0.tgz",
+      "integrity": "sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 18"
@@ -3827,16 +3801,16 @@
       }
     },
     "node_modules/source-map-loader": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-4.0.2.tgz",
-      "integrity": "sha512-oYwAqCuL0OZhBoSgmdrLa7mv9MjommVMiQIWgcztf+eS4+8BfcUee6nenFnDhKOhzAVnk5gpZdfnz1iiBv+5sg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-5.0.0.tgz",
+      "integrity": "sha512-k2Dur7CbSLcAH73sBcIkV5xjPV4SzqO1NJ7+XaQl8if3VODDUj3FNchNGpqgJSKbvUfJuhVdv8K2Eu8/TNl2eA==",
       "license": "MIT",
       "dependencies": {
         "iconv-lite": "^0.6.3",
         "source-map-js": "^1.0.2"
       },
       "engines": {
-        "node": ">= 14.15.0"
+        "node": ">= 18.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3933,9 +3907,9 @@
       }
     },
     "node_modules/tapable": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
-      "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -3946,9 +3920,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.46.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.0.tgz",
-      "integrity": "sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg==",
+      "version": "5.50.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.50.0.tgz",
+      "integrity": "sha512-CN9BVxWhgS/hRxtUMjtC2uRWSTcSfQFHMDWma6sKKfIivCD91sM+FOPfvwoaRMqCSrUpe1nv3jDamd9eEQ4y+w==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
@@ -3961,50 +3935,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/terser-webpack-plugin": {
-      "version": "5.3.16",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.16.tgz",
-      "integrity": "sha512-h9oBFCWrq78NyWWVcSwZarJkZ01c2AyGrzs1crmHZO3QUg9D61Wu4NPjBy69n7JqylFF5y+CsUZYmYEIZ3mR+Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.25",
-        "jest-worker": "^27.4.5",
-        "schema-utils": "^4.3.0",
-        "serialize-javascript": "^6.0.2",
-        "terser": "^5.31.1"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "webpack": "^5.1.0"
-      },
-      "peerDependenciesMeta": {
-        "@swc/core": {
-          "optional": true
-        },
-        "esbuild": {
-          "optional": true
-        },
-        "uglify-js": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/terser-webpack-plugin/node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.31",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
-      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.1.0",
-        "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "node_modules/text-table": {
@@ -4227,6 +4157,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -4302,12 +4241,11 @@
       "license": "MIT"
     },
     "node_modules/watchpack": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
-      "integrity": "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.2.tgz",
+      "integrity": "sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg==",
       "license": "MIT",
       "dependencies": {
-        "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
       },
       "engines": {
@@ -4329,36 +4267,31 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.104.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.104.1.tgz",
-      "integrity": "sha512-Qphch25abbMNtekmEGJmeRUhLDbe+QfiWTiqpKYkpCOWY64v9eyl+KRRLmqOFA2AvKPpc9DC6+u2n76tQLBoaA==",
+      "version": "5.109.2",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.109.2.tgz",
+      "integrity": "sha512-U9/cvLzxObKNEZ9+TtdqrHM5/9z3lgl2c+c4BzbqGxFQvQvBAq87yql5A8pQ+rrMbS496MZJeF5enVBndIy2hw==",
       "license": "MIT",
       "dependencies": {
-        "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
         "@types/json-schema": "^7.0.15",
         "@webassemblyjs/ast": "^1.14.1",
         "@webassemblyjs/wasm-edit": "^1.14.1",
         "@webassemblyjs/wasm-parser": "^1.14.1",
-        "acorn": "^8.15.0",
-        "acorn-import-phases": "^1.0.3",
+        "acorn": "^8.16.0",
         "browserslist": "^4.28.1",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.17.4",
-        "es-module-lexer": "^2.0.0",
+        "enhanced-resolve": "^5.24.4",
+        "es-module-lexer": "^2.1.0",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
-        "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.2.11",
-        "json-parse-even-better-errors": "^2.3.1",
-        "loader-runner": "^4.3.1",
-        "mime-types": "^2.1.27",
+        "mime-db": "^1.54.0",
+        "minimizer-webpack-plugin": "^5.6.1",
         "neo-async": "^2.6.2",
         "schema-utils": "^4.3.3",
         "tapable": "^2.3.0",
-        "terser-webpack-plugin": "^5.3.16",
-        "watchpack": "^2.4.4",
-        "webpack-sources": "^3.3.3"
+        "watchpack": "^2.5.2",
+        "webpack-sources": "^3.5.1"
       },
       "bin": {
         "webpack": "bin/webpack.js"
@@ -4377,9 +4310,9 @@
       }
     },
     "node_modules/webpack-sources": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.3.tgz",
-      "integrity": "sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.5.1.tgz",
+      "integrity": "sha512-jyuiGJdtvY434z5bUZrjz67v76/ePNvFZTp9Mdz29IlH4+GPsgyGjiv0fKI+M7BdkU6ADjulUcKAd3tUK3WlEw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.13.0"

--- a/agents/ai_sdk_by_vercel_typescript/package.json
+++ b/agents/ai_sdk_by_vercel_typescript/package.json
@@ -2,6 +2,9 @@
   "name": "temporal-ai-sdk-by-vercel-typescript-cookbook",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": ">=22.12.0"
+  },
   "scripts": {
     "build": "tsc --build",
     "build.watch": "tsc --build --watch",
@@ -20,19 +23,19 @@
     "watch": ["src"]
   },
   "dependencies": {
-    "@ai-sdk/openai": "^3.0.0",
-    "@ai-sdk/provider": "^3.0.0",
-    "@temporalio/ai-sdk": "^1.14.1",
-    "@temporalio/client": "^1.14.1",
-    "@temporalio/envconfig": "^1.14.1",
-    "@temporalio/worker": "^1.14.1",
-    "@temporalio/workflow": "^1.14.1",
-    "ai": "^6.0.0",
+    "@ai-sdk/openai": "^4.0.0",
+    "@ai-sdk/provider": "^4.0.0",
+    "@temporalio/ai-sdk": "^1.22.0",
+    "@temporalio/client": "^1.22.0",
+    "@temporalio/envconfig": "^1.22.0",
+    "@temporalio/worker": "^1.22.0",
+    "@temporalio/workflow": "^1.22.0",
+    "ai": "^7.0.0",
     "nanoid": "3.x",
     "zod": "^3.25.76"
   },
   "devDependencies": {
-    "@tsconfig/node18": "^18.2.4",
+    "@tsconfig/node22": "^22.0.5",
     "@types/node": "^22.9.1",
     "@typescript-eslint/eslint-plugin": "^8.18.0",
     "@typescript-eslint/parser": "^8.18.0",
@@ -42,7 +45,7 @@
     "nodemon": "^3.1.7",
     "prettier": "^3.4.2",
     "ts-node": "^10.9.2",
-    "typescript": "^5.6.3"
+    "typescript": "^5.9.3"
   }
 }
 

--- a/agents/ai_sdk_by_vercel_typescript/src/workflows.ts
+++ b/agents/ai_sdk_by_vercel_typescript/src/workflows.ts
@@ -1,7 +1,6 @@
-import '@temporalio/ai-sdk/lib/load-polyfills';
 import type * as activities from './activities';
 import { generateText, stepCountIs, tool } from 'ai';
-import { temporalProvider } from '@temporalio/ai-sdk';
+import { temporalProvider } from '@temporalio/ai-sdk/workflow';
 import { proxyActivities } from '@temporalio/workflow';
 import z from 'zod';
 

--- a/agents/ai_sdk_by_vercel_typescript/tsconfig.json
+++ b/agents/ai_sdk_by_vercel_typescript/tsconfig.json
@@ -1,8 +1,11 @@
 {
-  "extends": "@tsconfig/node18/tsconfig.json",
-  "version": "5.6.3",
+  "extends": "@tsconfig/node22/tsconfig.json",
+  "version": "5.9.3",
   "compilerOptions": {
-    "lib": ["es2021"],
+    // The AI SDK is ESM-only as of v7. `nodenext` lets this CommonJS project
+    // `require()` those packages, which Node supports as of 22.12.
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,


### PR DESCRIPTION
Bumps `ai` to ^7, `@ai-sdk/openai` and `@ai-sdk/provider` to ^4, and `@temporalio/*` to ^1.22.0 (1.14 peers on `ai` ^6; 1.22 is the first release peering on ^7).

Two breaking changes came with the bump.

**`ai`@7 and `@ai-sdk/openai`@4 ship no CommonJS build**, so `tsc` rejected the imports with TS1479. Rather than convert the recipe to ESM — which would mean `"type": "module"`, tsx instead of ts-node, and replacing `require.resolve('./workflows')` in the Worker — this sets `module`/`moduleResolution` to `nodenext` so the CommonJS project can `require()` them, which TypeScript allows as of 5.8 and Node supports as of 22.12. The recipe source stays CommonJS and unchanged. Adds an `engines` field and a README note for the Node requirement, and bumps TypeScript to ^5.9.3 and the tsconfig base to `@tsconfig/node22` to match.

**`@temporalio/ai-sdk`@1.22 added an `exports` field** with only `.` and `./workflow`, so the deep import of `lib/load-polyfills` no longer resolves and the Workflow bundler failed with "not exported under the conditions". `AiSdkPlugin.configureBundler` now prepends the polyfill installer to the bundle automatically, so `src/workflows.ts` drops that import and takes `temporalProvider` from `@temporalio/ai-sdk/workflow` — the package root pulls in Worker-side Activities the bundler disallows.

## Verification

From a clean `node_modules`:

- `npm install` with no peer or engine warnings
- `tsc --noEmit` and `npm run build` clean
- Worker starts and bundles the Workflow successfully
- A real Workflow execution against the dev server reached the `invokeModel` Activity, which called OpenAI and failed only on a deliberately invalid API key (`AI_APICallError: Incorrect API key`)

No valid `OPENAI_API_KEY` was available, so the end of the agentic loop — model response, tool call, final text — is unverified; everything up to the HTTP call is.

Two pre-existing issues left alone: `npm run lint` fails because the repo has no ESLint config file, and `npm run format:check` already flagged unmodified files including `README.md` and `src/activities.ts`. CI runs no TypeScript job for this recipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)