### PR TITLE
Bump docs listing priority for LiteLLM and Vercel AI SDK recipes

### DIFF
--- a/agents/ai_sdk_by_vercel_typescript/README.md
+++ b/agents/ai_sdk_by_vercel_typescript/README.md
@@ -1,7 +1,7 @@
 <!--
 description: Build a durable AI agent with the AI SDK by Vercel and Temporal that chooses tools to answer user questions.
 tags: [agents, typescript, openai]
-priority: 750
+priority: 980
 -->
 
 # Durable agent with tools using the AI SDK by Vercel

--- a/foundations/hello_world_litellm_python/README.md
+++ b/foundations/hello_world_litellm_python/README.md
@@ -1,7 +1,7 @@
 <!-- 
 description: Integrate LiteLLM into a durable Temporal Workflow in Python to call and switch between LLM providers.
 tags: [foundations, python, litellm]
-priority: 920
+priority: 990
 -->
 
 # Hello world with LiteLLM


### PR DESCRIPTION
## Summary
- Raises `foundations/hello_world_litellm_python` priority from 920 to 990, moving it just below the Hello World OpenAI recipe in the Foundations listing.
- Raises `agents/ai_sdk_by_vercel_typescript` priority from 750 to 980, moving it to the top of the Agents listing on docs.temporal.io.

## Test plan
- [x] No code changes; front matter only, `priority` is a plain integer field validated by CI's front-matter check.